### PR TITLE
Make `LAST_ERROR` public within crate

### DIFF
--- a/ffi-utils/src/errors.rs
+++ b/ffi-utils/src/errors.rs
@@ -3,7 +3,7 @@ macro_rules! generate_error_handling {
     ($get_error_symbol:ident) => {
         use std::cell::RefCell;
         thread_local! {
-            static LAST_ERROR: RefCell<Option<String>> = RefCell::new(None);
+            pub(crate) static LAST_ERROR: RefCell<Option<String>> = RefCell::new(None);
         }
 
         fn _get_last_error(


### PR DESCRIPTION
What
-- 
Make the `LAST_ERROR` variable public to allow the use of the `wrap!` macro beyond the module in which `generate_error_handling!` is invoked.

Why
--
Enable modularisation of code that relies on `wrap!`