### PR TITLE
Enable pointer working for both optional fields and redirection fields

### DIFF
--- a/ffi-utils-derive/src/lib.rs
+++ b/ffi-utils-derive/src/lib.rs
@@ -35,29 +35,54 @@ fn impl_creprof_macro(input: &syn::DeriveInput) -> TokenStream {
         .map(|field|
             (field.ident.as_ref().expect("field should have an ident"),
              match &field.ty {
-                 Type::Ptr(ptr_t) => { match &*ptr_t.elem {
-                     Type::Path(path_t) => quote!(ffi_utils::RawPointerTo::< #path_t >),
-                     _ => panic!("")
-                 }}
-                 Type::Path(path_t) => { generic_path_to_concrete_type_path(&path_t.path) }
+                 Type::Ptr(ptr_t) => {
+                     match &*ptr_t.elem {
+                         Type::Path(path_t) => {
+                             if let Some(_it) = path_t.path.segments.iter().find(|it| {
+                                 it.ident.to_string().contains("c_char")
+                             }) {
+                                 // it's a pointer to str, return tuple of (composed_type, is_str_flag)
+                                 (quote!(ffi_utils::RawPointerTo::< #path_t >), true)
+                             } else {
+                                 (quote!(ffi_utils::RawPointerTo::< #path_t >), false)
+                             }
+                         }
+                         _ => panic!("")
+                     }
+                 }
+                 Type::Path(path_t) => { (generic_path_to_concrete_type_path(&path_t.path), false) }
                  _ => { panic!("") }
              },
              &field.attrs))
-        .map(|(field_name, field_type, field_attrs)| {
+        .map(|(field_name, (field_type, is_str), field_attrs)| {
             let nullable = field_attrs.iter().find(|attr| {
                 attr.path.get_ident().map(|it| it.to_string()) == Some("nullable".into())
             });
 
             if let Some(_it) = nullable {
-                quote!(
-                    #field_name: if let Some(it) = input.#field_name {
-                        #field_type::c_repr_of(it)?
-                    } else {
-                        std::ptr::null() as _
-                    }
-                )
+                if is_str {
+                    quote!(
+                        #field_name: if let Some(it) = input.#field_name {
+                            convert_to_c_string_result!(it)?
+                        } else {
+                            std::ptr::null() as _
+                        }
+                    )
+                } else {
+                    quote!(
+                        #field_name: if let Some(it) = input.#field_name {
+                            #field_type::c_repr_of(it)?
+                        } else {
+                            std::ptr::null() as _
+                        }
+                    )
+                }
             } else {
-                quote!(#field_name: #field_type ::c_repr_of(input.#field_name)?)
+                if is_str {
+                    quote!(#field_name: convert_to_c_string_result!(input.#field_name)?)
+                } else {
+                    quote!(#field_name: #field_type ::c_repr_of(input.#field_name)?)
+                }
             }
         })
         .collect::<Vec<_>>();
@@ -70,8 +95,7 @@ fn impl_creprof_macro(input: &syn::DeriveInput) -> TokenStream {
                 })
             }
         }
-    )
-    .into()
+    ).into()
 }
 
 fn generic_path_to_concrete_type_path(path: &syn::Path) -> proc_macro2::TokenStream {
@@ -80,7 +104,7 @@ fn generic_path_to_concrete_type_path(path: &syn::Path) -> proc_macro2::TokenStr
     let segments = &path.segments;
     let ident = &last_segment.value().ident;
     let turbofished_type = if let syn::PathArguments::AngleBracketed(bracketed_args) =
-        &last_segment.value().arguments
+    &last_segment.value().arguments
     {
         quote!(#ident::#bracketed_args)
     } else {
@@ -120,24 +144,58 @@ fn impl_asrust_macro(input: &syn::DeriveInput) -> TokenStream {
         .fields
         .iter()
         .map(|field|
-            (field.ident.as_ref().expect("field should have an ident"),
-             &field.attrs)
+            (
+                field.ident.as_ref().expect("field should have an ident"),
+                match &field.ty {
+                    Type::Ptr(ptr_t) => {
+                        match &*ptr_t.elem {
+                            Type::Path(path_t) => {
+                                if let Some(_it) = path_t.path.segments.iter().find(|it| {
+                                    it.ident.to_string().contains("c_char")
+                                }) {
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                            _ => panic!("")
+                        }
+                    }
+                    Type::Path(_path_t) => false,
+                    _ => { panic!("") }
+                },
+                &field.attrs
+            )
         )
-        .map(|(field_name, field_attrs)| {
+        .map(|(field_name, is_str, field_attrs)| {
             let nullable = field_attrs.iter().find(|attr| {
                 attr.path.get_ident().map(|it| it.to_string()) == Some("nullable".into())
             });
 
             if let Some(_it) = nullable {
-                quote!(
-                    #field_name: if self.#field_name != std::ptr::null() {
-                        Some(self.#field_name.as_rust()?)
-                    } else {
-                        None
-                    }
-                )
+                if is_str {
+                    quote!(
+                        #field_name: if self.#field_name != std::ptr::null() {
+                            Some(create_rust_string_from!(self.#field_name)?)
+                        } else {
+                            None
+                        }
+                    )
+                } else {
+                    quote!(
+                        #field_name: if self.#field_name != std::ptr::null() {
+                            Some(self.#field_name.as_rust()?)
+                        } else {
+                            None
+                        }
+                    )
+                }
             } else {
-                quote!(#field_name : self.#field_name.as_rust()?)
+                if is_str {
+                    quote!(#field_name : create_rust_string_from!(self.#field_name))
+                } else {
+                    quote!(#field_name : self.#field_name.as_rust()?)
+                }
             }
         })
         .collect::<Vec<_>>();
@@ -150,6 +208,5 @@ fn impl_asrust_macro(input: &syn::DeriveInput) -> TokenStream {
                 })
             }
         }
-    )
-    .into()
+    ).into()
 }

--- a/ffi-utils-derive/src/lib.rs
+++ b/ffi-utils-derive/src/lib.rs
@@ -7,7 +7,7 @@ use syn::Type;
 
 use quote::quote;
 
-#[proc_macro_derive(CReprOf, attributes(converted))]
+#[proc_macro_derive(CReprOf, attributes(converted, nullable))]
 pub fn creprof_derive(token_stream: TokenStream) -> TokenStream {
     let ast = syn::parse(token_stream).unwrap();
     impl_creprof_macro(&ast)
@@ -41,10 +41,25 @@ fn impl_creprof_macro(input: &syn::DeriveInput) -> TokenStream {
                  }}
                  Type::Path(path_t) => { generic_path_to_concrete_type_path(&path_t.path) }
                  _ => { panic!("") }
-             }))
-        .map(|(field_name, field_type)|
-            quote!(#field_name: #field_type ::c_repr_of(input.#field_name)?)
-        )
+             },
+             &field.attrs))
+        .map(|(field_name, field_type, field_attrs)| {
+            let nullable = field_attrs.iter().find(|attr| {
+                attr.path.get_ident().map(|it| it.to_string()) == Some("nullable".into())
+            });
+
+            if let Some(_it) = nullable {
+                quote!(
+                    #field_name: if let Some(it) = input.#field_name {
+                        #field_type::c_repr_of(it)?
+                    } else {
+                        std::ptr::null() as _
+                    }
+                )
+            } else {
+                quote!(#field_name: #field_type ::c_repr_of(input.#field_name)?)
+            }
+        })
         .collect::<Vec<_>>();
 
     quote!(
@@ -78,7 +93,7 @@ fn generic_path_to_concrete_type_path(path: &syn::Path) -> proc_macro2::TokenStr
     }
 }
 
-#[proc_macro_derive(AsRust, attributes(converted))]
+#[proc_macro_derive(AsRust, attributes(converted, nullable))]
 pub fn asrust_derive(token_stream: TokenStream) -> TokenStream {
     let ast = syn::parse(token_stream).unwrap();
     impl_asrust_macro(&ast)
@@ -104,8 +119,27 @@ fn impl_asrust_macro(input: &syn::DeriveInput) -> TokenStream {
     let fields: Vec<_> = data
         .fields
         .iter()
-        .map(|field| field.ident.as_ref().expect("field should have an ident"))
-        .map(|field_name| quote!(#field_name : self.#field_name .as_rust()?))
+        .map(|field|
+            (field.ident.as_ref().expect("field should have an ident"),
+             &field.attrs)
+        )
+        .map(|(field_name, field_attrs)| {
+            let nullable = field_attrs.iter().find(|attr| {
+                attr.path.get_ident().map(|it| it.to_string()) == Some("nullable".into())
+            });
+
+            if let Some(_it) = nullable {
+                quote!(
+                    #field_name: if self.#field_name != std::ptr::null() {
+                        Some(self.#field_name.as_rust()?)
+                    } else {
+                        None
+                    }
+                )
+            } else {
+                quote!(#field_name : self.#field_name.as_rust()?)
+            }
+        })
         .collect::<Vec<_>>();
 
     quote!(

--- a/ffi-utils-derive/src/lib.rs
+++ b/ffi-utils-derive/src/lib.rs
@@ -3,7 +3,6 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 
 use syn;
-use syn::Type;
 
 use quote::quote;
 
@@ -14,75 +13,33 @@ pub fn creprof_derive(token_stream: TokenStream) -> TokenStream {
 }
 
 fn impl_creprof_macro(input: &syn::DeriveInput) -> TokenStream {
-    let data = match &input.data {
-        syn::Data::Struct(data) => data,
-        _ => panic!("CReprOf can only be derived for structs"),
-    };
-
     let struct_name = &input.ident;
+    let target_type = parse_target_type(&input.attrs);
 
-    let converted_attribute: &syn::Attribute = input
-        .attrs
+    let fields = parse_data_to_fields(&input.data)
         .iter()
-        .find(|attribute| {
-            attribute.path.get_ident().map(|it| it.to_string()) == Some("converted".into())
-        })
-        .expect("Can't derive CReprOf without converted helper attribute.");
-
-    let target_type: syn::Path = converted_attribute.parse_args().unwrap();
-
-    let fields: Vec<_> = data.fields.iter()
-        .map(|field|
-            (field.ident.as_ref().expect("field should have an ident"),
-             match &field.ty {
-                 Type::Ptr(ptr_t) => {
-                     match &*ptr_t.elem {
-                         Type::Path(path_t) => {
-                             if let Some(_it) = path_t.path.segments.iter().find(|it| {
-                                 it.ident.to_string().contains("c_char")
-                             }) {
-                                 // it's a pointer to str, return tuple of (composed_type, is_str_flag)
-                                 (quote!(ffi_utils::RawPointerTo::< #path_t >), true)
-                             } else {
-                                 (quote!(ffi_utils::RawPointerTo::< #path_t >), false)
-                             }
-                         }
-                         _ => panic!("")
-                     }
-                 }
-                 Type::Path(path_t) => { (generic_path_to_concrete_type_path(&path_t.path), false) }
-                 _ => { panic!("") }
-             },
-             &field.attrs))
-        .map(|(field_name, (field_type, is_str), field_attrs)| {
-            let nullable = field_attrs.iter().find(|attr| {
-                attr.path.get_ident().map(|it| it.to_string()) == Some("nullable".into())
-            });
-
-            if let Some(_it) = nullable {
-                if is_str {
+        .map(|(field_name, field_type, is_str, is_nullable)| {
+            match (is_nullable, is_str) {
+                (true, true) =>
                     quote!(
-                        #field_name: if let Some(it) = input.#field_name {
-                            convert_to_c_string_result!(it)?
+                        #field_name: if let Some(value) = input.#field_name {
+                            convert_to_c_string_result!(value)?
                         } else {
                             std::ptr::null() as _
                         }
-                    )
-                } else {
+                    ),
+                (true, false) =>
                     quote!(
-                        #field_name: if let Some(it) = input.#field_name {
-                            #field_type::c_repr_of(it)?
+                        #field_name: if let Some(value) = input.#field_name {
+                            #field_type::c_repr_of(value)?
                         } else {
                             std::ptr::null() as _
                         }
-                    )
-                }
-            } else {
-                if is_str {
-                    quote!(#field_name: convert_to_c_string_result!(input.#field_name)?)
-                } else {
-                    quote!(#field_name: #field_type ::c_repr_of(input.#field_name)?)
-                }
+                    ),
+                (false, true) =>
+                    quote!(#field_name: convert_to_c_string_result!(input.#field_name)?),
+                (false, false) =>
+                    quote!(#field_name: #field_type ::c_repr_of(input.#field_name)?),
             }
         })
         .collect::<Vec<_>>();
@@ -96,6 +53,110 @@ fn impl_creprof_macro(input: &syn::DeriveInput) -> TokenStream {
             }
         }
     ).into()
+}
+
+#[proc_macro_derive(AsRust, attributes(converted, nullable))]
+pub fn asrust_derive(token_stream: TokenStream) -> TokenStream {
+    let ast = syn::parse(token_stream).unwrap();
+    impl_asrust_macro(&ast)
+}
+
+fn impl_asrust_macro(input: &syn::DeriveInput) -> TokenStream {
+    let struct_name = &input.ident;
+    let target_type = parse_target_type(&input.attrs);
+
+    let fields = parse_data_to_fields(&input.data)
+        .iter()
+        .map(|(field_name, _, is_str, is_nullable)| {
+            match (is_nullable, is_str) {
+                (true, true) =>
+                    quote!(
+                        #field_name: if self.#field_name != std::ptr::null() {
+                            Some(create_rust_string_from!(self.#field_name))
+                        } else {
+                            None
+                        }
+                    ),
+                (true, false) =>
+                    quote!(
+                        #field_name: if self.#field_name != std::ptr::null() {
+                            Some(self.#field_name.as_rust()?)
+                        } else {
+                            None
+                        }
+                    ),
+                (false, true) =>
+                    quote!(#field_name : create_rust_string_from!(self.#field_name)),
+                (false, false) =>
+                    quote!(#field_name : self.#field_name.as_rust()?)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    quote!(
+        impl AsRust<#target_type> for #struct_name {
+            fn as_rust(&self) -> Result<#target_type, ffi_utils::Error> {
+                Ok(#target_type {
+                    #(#fields, )*
+                })
+            }
+        }
+    ).into()
+}
+
+fn parse_target_type(attrs: &Vec<syn::Attribute>) -> syn::Path {
+    let converted_attribute= attrs
+        .iter()
+        .find(|attribute| {
+            attribute.path.get_ident().map(|it| it.to_string()) == Some("converted".into())
+        })
+        .expect("Can't derive CReprOf without converted helper attribute.");
+
+    converted_attribute.parse_args().unwrap()
+}
+
+fn parse_data_to_fields(data: &syn::Data) -> Vec<(&syn::Ident, proc_macro2::TokenStream, bool, bool)> {
+    match &data {
+        syn::Data::Struct(data_struct) =>
+            data_struct.fields
+                .iter()
+                .map(|field| parse_field(field))
+                .collect::<Vec<(&syn::Ident, proc_macro2::TokenStream, bool, bool)>>(),
+        _ => panic!("CReprOf / AsRust can only be derived for structs"),
+    }
+}
+
+fn parse_field(field: &syn::Field) -> (&syn::Ident, proc_macro2::TokenStream, bool, bool) {
+    let field_name = field.ident.as_ref().expect("Field should have an ident");
+
+    let is_nullable = field.attrs.iter().find(|attr| {
+        attr.path.get_ident().map(|it| it.to_string()) == Some("nullable".into())
+    }).is_some();
+
+    let (field_type, is_str) = match &field.ty {
+        syn::Type::Ptr(ptr_t) => {
+            match &*ptr_t.elem {
+                syn::Type::Path(path_t) => {
+                    // Check if it's string type
+                    let is_str = path_t
+                        .path
+                        .segments
+                        .iter()
+                        .find(|it| it.ident.to_string().contains("c_char"));
+
+                    match is_str {
+                        Some(_) => (quote!(ffi_utils::RawPointerTo::< #path_t >), true),
+                        None => (quote!(ffi_utils::RawPointerTo::< #path_t >), false)
+                    }
+                }
+                _ => panic!("Pointer type is not supported")
+            }
+        }
+        syn::Type::Path(path_t) => (generic_path_to_concrete_type_path(&path_t.path), false),
+        _ => { panic!("Field type is not supported") }
+    };
+
+    (field_name, field_type, is_str, is_nullable)
 }
 
 fn generic_path_to_concrete_type_path(path: &syn::Path) -> proc_macro2::TokenStream {
@@ -115,98 +176,4 @@ fn generic_path_to_concrete_type_path(path: &syn::Path) -> proc_macro2::TokenStr
     } else {
         quote!(#segments::#turbofished_type)
     }
-}
-
-#[proc_macro_derive(AsRust, attributes(converted, nullable))]
-pub fn asrust_derive(token_stream: TokenStream) -> TokenStream {
-    let ast = syn::parse(token_stream).unwrap();
-    impl_asrust_macro(&ast)
-}
-
-fn impl_asrust_macro(input: &syn::DeriveInput) -> TokenStream {
-    let struct_name = &input.ident;
-    let converted_attribute: &syn::Attribute = input
-        .attrs
-        .iter()
-        .find(|attribute| {
-            attribute.path.get_ident().map(|it| it.to_string()) == Some("converted".into())
-        })
-        .expect("Can't derive CReprOf without converted helper attribute.");
-
-    let target_type: syn::Path = converted_attribute.parse_args().unwrap();
-
-    let data = match &input.data {
-        syn::Data::Struct(data) => data,
-        _ => panic!("CReprOf can only be derived for structs"),
-    };
-
-    let fields: Vec<_> = data
-        .fields
-        .iter()
-        .map(|field|
-            (
-                field.ident.as_ref().expect("field should have an ident"),
-                match &field.ty {
-                    Type::Ptr(ptr_t) => {
-                        match &*ptr_t.elem {
-                            Type::Path(path_t) => {
-                                if let Some(_it) = path_t.path.segments.iter().find(|it| {
-                                    it.ident.to_string().contains("c_char")
-                                }) {
-                                    true
-                                } else {
-                                    false
-                                }
-                            }
-                            _ => panic!("")
-                        }
-                    }
-                    Type::Path(_path_t) => false,
-                    _ => { panic!("") }
-                },
-                &field.attrs
-            )
-        )
-        .map(|(field_name, is_str, field_attrs)| {
-            let nullable = field_attrs.iter().find(|attr| {
-                attr.path.get_ident().map(|it| it.to_string()) == Some("nullable".into())
-            });
-
-            if let Some(_it) = nullable {
-                if is_str {
-                    quote!(
-                        #field_name: if self.#field_name != std::ptr::null() {
-                            Some(create_rust_string_from!(self.#field_name)?)
-                        } else {
-                            None
-                        }
-                    )
-                } else {
-                    quote!(
-                        #field_name: if self.#field_name != std::ptr::null() {
-                            Some(self.#field_name.as_rust()?)
-                        } else {
-                            None
-                        }
-                    )
-                }
-            } else {
-                if is_str {
-                    quote!(#field_name : create_rust_string_from!(self.#field_name))
-                } else {
-                    quote!(#field_name : self.#field_name.as_rust()?)
-                }
-            }
-        })
-        .collect::<Vec<_>>();
-
-    quote!(
-        impl AsRust<#target_type> for #struct_name {
-            fn as_rust(&self) -> Result<#target_type, ffi_utils::Error> {
-                Ok(#target_type {
-                    #(#fields, )*
-                })
-            }
-        }
-    ).into()
 }

--- a/ffi-utils-tests/Cargo.toml
+++ b/ffi-utils-tests/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 failure = "0.1"
 ffi-utils = { path = "../ffi-utils" }
+libc = "0.2.66"

--- a/ffi-utils-tests/src/lib.rs
+++ b/ffi-utils-tests/src/lib.rs
@@ -17,8 +17,9 @@ mod tests {
         start: f32,
         end: f32,
         dummy: CDummy,
+        #[nullable]
         sauce: *const CSauce,
-        toppings: CArray<CTopping>,
+        toppings: *const CArray<CTopping>
     }
 
     pub struct Sauce {

--- a/ffi-utils-tests/src/lib.rs
+++ b/ffi-utils-tests/src/lib.rs
@@ -4,11 +4,13 @@ use ffi_utils::*;
 
 pub struct Pancake {
     pub name: String,
+    pub description: Option<String>,
     pub start: f32,
-    pub end: f32,
+    pub end: Option<f32>,
     pub dummy: Dummy,
     pub sauce: Option<Sauce>,
     pub toppings: Vec<Topping>,
+    pub layers: Option<Vec<Layer>>
 }
 
 #[repr(C)]
@@ -16,12 +18,17 @@ pub struct Pancake {
 #[converted(Pancake)]
 pub struct CPancake {
     name: *const libc::c_char,
+    #[nullable]
+    description: *const libc::c_char,
     start: f32,
-    end: f32,
+    #[nullable]
+    end: *const f32,
     dummy: CDummy,
     #[nullable]
     sauce: *const CSauce,
     toppings: *const CArray<CTopping>,
+    #[nullable]
+    layers: *const CArray<CLayer>
 }
 
 pub struct Sauce {
@@ -46,6 +53,20 @@ pub struct CTopping {
     amount: i32,
 }
 
+pub struct Layer {
+    pub number: i32,
+    pub subtitle: Option<String>
+}
+
+#[repr(C)]
+#[derive(CReprOf, AsRust)]
+#[converted(Layer)]
+pub struct CLayer {
+    number: i32,
+    #[nullable]
+    subtitle: *const libc::c_char,
+}
+
 pub struct Dummy {
     pub count: i32,
 }
@@ -65,18 +86,27 @@ mod tests {
     fn should_work() {
         let input = Pancake {
             name: String::from("Here is your pancake"),
+            description: None,
             start: 0.0,
-            end: 2.0,
+            end: Some(2.0),
             dummy: Dummy { count: 2 },
             sauce: None,
             toppings: vec![Topping { amount: 2 }, Topping { amount: 3 }],
+            layers: Some(vec![Layer { number: 1, subtitle: Some(String::from("first layer"))}]),
         };
 
         let output = CPancake::c_repr_of(input).unwrap().as_rust().unwrap();
 
         assert!(String::from("Here is your pancake").eq(&output.name));
+        assert!(match output.description {
+            Some(_) => false,
+            None => true
+        });
         assert_eq!(output.start.clone(), 0.0);
-        assert_eq!(output.end.clone(), 2.0);
+        assert!(match output.end {
+            Some(value) => value == 2.0,
+            None => false
+        });
         assert_eq!(output.dummy.count.clone(), 2);
         assert!(match output.sauce {
             Some(_) => false,
@@ -84,5 +114,15 @@ mod tests {
         });
         assert_eq!(output.toppings[0].amount, 2);
         assert_eq!(output.toppings[1].amount, 3);
+        assert!(match output.layers {
+            Some(layer) => {
+                (if let Some(s) = &layer[0].subtitle {
+                    String::from("first layer").eq(s)
+                } else {
+                    false
+                }) && (layer[0].number == 1)
+            },
+            None => false
+        });
     }
 }

--- a/ffi-utils-tests/src/lib.rs
+++ b/ffi-utils-tests/src/lib.rs
@@ -1,63 +1,70 @@
+use failure::*;
+
+use ffi_utils::*;
+
+pub struct Pancake {
+    pub name: String,
+    pub start: f32,
+    pub end: f32,
+    pub dummy: Dummy,
+    pub sauce: Option<Sauce>,
+    pub toppings: Vec<Topping>,
+}
+
+#[repr(C)]
+#[derive(CReprOf, AsRust)]
+#[converted(Pancake)]
+pub struct CPancake {
+    name: *const libc::c_char,
+    start: f32,
+    end: f32,
+    dummy: CDummy,
+    #[nullable]
+    sauce: *const CSauce,
+    toppings: *const CArray<CTopping>,
+}
+
+pub struct Sauce {
+    pub volume: f32,
+}
+
+#[repr(C)]
+#[derive(CReprOf, AsRust)]
+#[converted(Sauce)]
+pub struct CSauce {
+    volume: f32,
+}
+
+pub struct Topping {
+    pub amount: i32,
+}
+
+#[repr(C)]
+#[derive(CReprOf, AsRust)]
+#[converted(Topping)]
+pub struct CTopping {
+    amount: i32,
+}
+
+pub struct Dummy {
+    pub count: i32,
+}
+
+#[repr(C)]
+#[derive(CReprOf, AsRust)]
+#[converted(Dummy)]
+pub struct CDummy {
+    count: i32,
+}
+
 #[cfg(test)]
 mod tests {
-    use ffi_utils::{AsRust, CArray, CReprOf};
-
-    pub struct Pancake {
-        pub start: f32,
-        pub end: f32,
-        pub dummy: Dummy,
-        pub sauce: Option<Sauce>,
-        pub toppings: Vec<Topping>,
-    }
-
-    #[repr(C)]
-    #[derive(CReprOf, AsRust)]
-    #[converted(Pancake)]
-    pub struct CPancake {
-        start: f32,
-        end: f32,
-        dummy: CDummy,
-        #[nullable]
-        sauce: *const CSauce,
-        toppings: *const CArray<CTopping>
-    }
-
-    pub struct Sauce {
-        pub volume: f32,
-    }
-
-    #[repr(C)]
-    #[derive(CReprOf, AsRust)]
-    #[converted(Sauce)]
-    pub struct CSauce {
-        volume: f32,
-    }
-
-    pub struct Topping {
-        pub amount: i32,
-    }
-
-    #[repr(C)]
-    #[derive(CReprOf, AsRust)]
-    #[converted(Topping)]
-    pub struct CTopping {
-        amount: i32,
-    }
-
-    pub struct Dummy {
-        pub count: i32,
-    }
-
-    #[repr(C)]
-    #[derive(CReprOf, AsRust)]
-    #[converted(Dummy)]
-    pub struct CDummy {
-        count: i32,
-    }
+    use super::*;
 
     #[test]
     fn should_work() {
-        let pancakes = Pancake {
+        let input = Pancake {
+            name: String::from("Here is your pancake"),
             start: 0.0,
             end: 2.0,
             dummy: Dummy { count: 2 },
@@ -65,6 +72,17 @@ mod tests {
             toppings: vec![Topping { amount: 2 }, Topping { amount: 3 }],
         };
 
-        let _c_pancakes = CPancake::c_repr_of(pancakes).unwrap();
+        let output = CPancake::c_repr_of(input).unwrap().as_rust().unwrap();
+
+        assert!(String::from("Here is your pancake").eq(&output.name));
+        assert_eq!(output.start.clone(), 0.0);
+        assert_eq!(output.end.clone(), 2.0);
+        assert_eq!(output.dummy.count.clone(), 2);
+        assert!(match output.sauce {
+            Some(_) => false,
+            None => true
+        });
+        assert_eq!(output.toppings[0].amount, 2);
+        assert_eq!(output.toppings[1].amount, 3);
     }
 }

--- a/ffi-utils/src/conversions.rs
+++ b/ffi-utils/src/conversions.rs
@@ -238,6 +238,12 @@ impl CReprOf<String> for std::ffi::CString {
     }
 }
 
+impl CReprOf<String> for libc::c_char {
+    fn c_repr_of(input: String) -> Result<Self, Error> {
+        Ok(unsafe { *std::ffi::CString::c_repr_of(input).map(|s| s.into_raw_pointer() as *const libc::c_char)? })
+    }
+}
+
 impl CReprOf<f32> for f32 {
     fn c_repr_of(input: f32) -> Result<f32, Error> {
         Ok(input)

--- a/ffi-utils/src/conversions.rs
+++ b/ffi-utils/src/conversions.rs
@@ -236,12 +236,6 @@ impl CReprOf<String> for std::ffi::CString {
     }
 }
 
-impl CReprOf<String> for libc::c_char {
-    fn c_repr_of(input: String) -> Result<Self, Error> {
-        Ok(unsafe { *std::ffi::CString::c_repr_of(input).map(|s| s.into_raw_pointer() as *const libc::c_char)? })
-    }
-}
-
 impl CReprOf<f32> for f32 {
     fn c_repr_of(input: f32) -> Result<f32, Error> {
         Ok(input)

--- a/ffi-utils/src/conversions.rs
+++ b/ffi-utils/src/conversions.rs
@@ -1,7 +1,5 @@
 use failure::{ensure, format_err, Error, ResultExt};
 
-use std::ptr::null;
-
 #[macro_export]
 macro_rules! convert_to_c_string {
     ($string:expr) => {
@@ -258,13 +256,9 @@ impl CReprOf<i32> for i32 {
 
 pub type RawPointerTo<T> = *const T;
 
-impl<U: CReprOf<V>, V> CReprOf<Option<V>> for RawPointerTo<U> {
-    fn c_repr_of(input: Option<V>) -> Result<Self, Error> {
-        Ok(if let Some(inp) = input {
-            U::c_repr_of(inp)?.into_raw_pointer()
-        } else {
-            null() as *const _
-        })
+impl<U: CReprOf<V>, V> CReprOf<V> for RawPointerTo<U> {
+    fn c_repr_of(input: V) -> Result<Self, Error> {
+        Ok(U::c_repr_of(input)?.into_raw_pointer())
     }
 }
 
@@ -286,12 +280,8 @@ impl AsRust<f32> for f32 {
     }
 }
 
-impl<U: AsRust<V>, V> AsRust<Option<V>> for RawPointerTo<U> {
-    fn as_rust(&self) -> Result<Option<V>, Error> {
-        Ok(if *self != null() {
-            Some(unsafe { U::as_rust(&U::from_raw_pointer(*self)?)? })
-        } else {
-            None
-        })
+impl<U: AsRust<V>, V> AsRust<V> for RawPointerTo<U> {
+    fn as_rust(&self) -> Result<V, Error> {
+        Ok(unsafe { U::as_rust(&U::from_raw_pointer(*self)?)? })
     }
 }


### PR DESCRIPTION
With this change, it makes `*const T` notation works for both nullable fields and redirectional fields.