### PR TITLE
Add conversion between <std::ops::Range> and <CRange>

### DIFF
--- a/ffi-convert-derive/Cargo.toml
+++ b/ffi-convert-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi-convert-derive"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Sonos"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/ffi-convert-tests/Cargo.toml
+++ b/ffi-convert-tests/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "ffi-convert-tests"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Sonos"]
 edition = "2018"
 
 [dependencies]
 failure = "0.1"
-ffi-convert = "0.1.2"
+ffi-convert = "0.2.0"
 libc = "0.2.66"

--- a/ffi-convert-tests/Cargo.toml
+++ b/ffi-convert-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi-convert-tests"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Sonos"]
 edition = "2018"
 

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -1,3 +1,4 @@
+use std::ops::Range;
 use failure::{bail, Fallible};
 use ffi_convert::*;
 
@@ -41,6 +42,7 @@ pub struct Pancake {
     pub toppings: Vec<Topping>,
     pub layers: Option<Vec<Layer>>,
     pub is_delicious: bool,
+    pub range: Range<usize>,
 }
 
 #[repr(C)]
@@ -60,6 +62,7 @@ pub struct CPancake {
     #[nullable]
     layers: *const CArray<CLayer>,
     is_delicious: u8,
+    pub range: CRange<i32>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -156,6 +159,10 @@ mod tests {
                 subtitle: Some(String::from("first layer")),
             }]),
             is_delicious: true,
+            range: Range {
+                start: 20,
+                end: 30,
+            }
         }
     });
 
@@ -173,6 +180,10 @@ mod tests {
             toppings: vec![],
             layers: Some(vec![]),
             is_delicious: true,
+            range: Range {
+                start: 50,
+                end: 100,
+            }
         }
     });
 }

--- a/ffi-convert/Cargo.toml
+++ b/ffi-convert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi-convert"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Sonos"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,6 +10,6 @@ readme = "../README.md"
 keywords = ["ffi"]
 
 [dependencies]
-ffi-convert-derive = "0.1.2"
+ffi-convert-derive = "0.2.0"
 failure = "0.1"
 libc = "0.2"

--- a/ffi-convert/src/types.rs
+++ b/ffi-convert/src/types.rs
@@ -211,7 +211,7 @@ pub struct CRange<T> {
     pub end: T,
 }
 
-impl<U: AsRust<V> + PartialOrd, V: PartialOrd> AsRust<Range<V>> for CRange<U> {
+impl<U: AsRust<V>, V: PartialOrd + PartialEq> AsRust<Range<V>> for CRange<U> {
     fn as_rust(&self) -> Result<Range<V>, Error> {
         Ok(Range {
             start: self.start.as_rust()?,
@@ -220,7 +220,7 @@ impl<U: AsRust<V> + PartialOrd, V: PartialOrd> AsRust<Range<V>> for CRange<U> {
     }
 }
 
-impl<U: CReprOf<V> + PartialOrd + CDrop, V: PartialOrd> CReprOf<Range<V>> for CRange<U> {
+impl<U: CReprOf<V> + CDrop, V: PartialOrd + PartialEq> CReprOf<Range<V>> for CRange<U> {
     fn c_repr_of(input: Range<V>) -> Result<Self, Error> {
         Ok(Self {
             start: U::c_repr_of(input.start)?,

--- a/ffi-convert/src/types.rs
+++ b/ffi-convert/src/types.rs
@@ -105,8 +105,6 @@ impl CDrop for CStringArray {
 /// let ctoppings = CArray::<CPizzaTopping>::c_repr_of(toppings);
 ///
 /// ```
-///
-///
 #[repr(C)]
 pub struct CArray<T> {
     data_ptr: *const T,
@@ -180,7 +178,7 @@ impl<T> Drop for CArray<T> {
 ///     pub range: Range<i32>
 /// }
 ///
-/// #[derive(AsRust CDrop, CReprOf, Debug, PartialEq)]
+/// #[derive(AsRust, CDrop, CReprOf, Debug, PartialEq)]
 /// #[target_type(Foo)]
 /// pub struct CFoo {
 ///     pub range: CRange<i32>
@@ -205,10 +203,7 @@ impl<T> Drop for CArray<T> {
 ///
 /// let foo_converted = c_foo.as_rust().unwrap();
 /// assert_eq!(foo_converted, foo);
-///
 /// ```
-///
-///
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct CRange<T> {
@@ -216,7 +211,7 @@ pub struct CRange<T> {
     pub end: T,
 }
 
-impl<U: AsRust<V>, V> AsRust<Range<V>> for CRange<U> {
+impl<U: AsRust<V> + PartialOrd, V: PartialOrd> AsRust<Range<V>> for CRange<U> {
     fn as_rust(&self) -> Result<Range<V>, Error> {
         Ok(Range {
             start: self.start.as_rust()?,
@@ -225,7 +220,7 @@ impl<U: AsRust<V>, V> AsRust<Range<V>> for CRange<U> {
     }
 }
 
-impl<U: CReprOf<V> + CDrop, V> CReprOf<Range<V>> for CRange<U> {
+impl<U: CReprOf<V> + PartialOrd + CDrop, V: PartialOrd> CReprOf<Range<V>> for CRange<U> {
     fn c_repr_of(input: Range<V>) -> Result<Self, Error> {
         Ok(Self {
             start: U::c_repr_of(input.start)?,


### PR DESCRIPTION
Usage & example: 

```rust
use ffi_convert::{CReprOf, AsRust, CDrop, CRange};
use std::ops::Range;

#[derive(Clone, Debug, PartialEq)]
pub struct Foo {
    pub range: Range<usize>
}

#[derive(AsRust CDrop, CReprOf, Debug, PartialEq)]
#[target_type(Foo)]
pub struct CFoo {
    pub range: CRange<i32>
}

let foo = Foo {
    range: Range {
        start: 20,
        end: 30,
    }
};

let c_foo = CFoo {
    range: CRange {
        start: 20,
        end: 30,
    }
};

let c_foo_converted = CFoo::c_repr_of(foo.clone()).unwrap();
assert_eq!(c_foo, c_foo_converted);

let foo_converted = c_foo.as_rust().unwrap();
assert_eq!(foo_converted, foo);
```