### PR TITLE
Fix : Fully qualified paths for field types in struct definitions

### DIFF
--- a/ffi-convert-derive/Cargo.toml
+++ b/ffi-convert-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi-convert-derive"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Sonos"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,8 +15,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
-syn = "1.0.16"
 
-[dev-dependencies.syn]
+[dependencies.syn]
 version = "1.0.16"
 features = ["extra-traits"]

--- a/ffi-convert-derive/Cargo.toml
+++ b/ffi-convert-derive/Cargo.toml
@@ -13,6 +13,10 @@ keywords = ["ffi"]
 proc-macro = true
 
 [dependencies]
-syn = "1.0.5"
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
+syn = "1.0.16"
+
+[dev-dependencies.syn]
+version = "1.0.16"
+features = ["extra-traits"]

--- a/ffi-convert-tests/Cargo.toml
+++ b/ffi-convert-tests/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-ffi-convert = "0.1.1"
+ffi-convert = "0.1.2"
 libc = "0.2.66"

--- a/ffi-convert/Cargo.toml
+++ b/ffi-convert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi-convert"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Sonos"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,6 +10,6 @@ readme = "../README.md"
 keywords = ["ffi"]
 
 [dependencies]
-ffi-convert-derive = "0.1.1"
+ffi-convert-derive = "0.1.2"
 failure = "0.1"
 libc = "0.2"


### PR DESCRIPTION
This P.R introduces a mechanism that allows for a correct derivation of traits: `CDrop`, `CReprOf`, `AsRust` when the field types are specified with paths. 

For instance : 
```rust
#[repr(C)]
#[derive(CDrop, AsRust, CReprOf)]
#[target_type(Foo)]
pub struct CFoo {
    field: *const libc::c_char,
    bar : *const bar_ffi::CBar
    bars: *const CArray<bar_ffi::CBar>,
}
```

