### PR TITLE
Fix u8i8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - `CDrop` and `CReprOf` are now implemented for `u8` and `i8`.
+
+### Changed
+ - `bool` in Rust is no longer converted to `u8` in C. Instead it is converted to `bool`, which is guaranteed to be the same as `_Bool` in C.
 
 ## [0.4.0] - 2020-12-17
 ### Added

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -46,6 +46,7 @@ pub struct Pancake {
     pub some_futile_info: Option<String>,
     pub flattened_range: Range<i64>,
     pub field_with_specific_rust_name: String,
+    pub pancake_data: Option<Vec<u8>>,
 }
 
 #[repr(C)]
@@ -66,7 +67,7 @@ pub struct CPancake {
     toppings: *const CArray<CTopping>,
     #[nullable]
     layers: *const CArray<CLayer>,
-    is_delicious: u8,
+    is_delicious: bool,
     pub range: CRange<i32>,
     #[c_repr_of_convert(input.flattened_range.start)]
     flattened_range_start: i64,
@@ -74,6 +75,8 @@ pub struct CPancake {
     flattened_range_end: i64,
     #[target_name(field_with_specific_rust_name)]
     pub field_with_specific_c_name: *const libc::c_char,
+    #[nullable]
+    pancake_data: *const CArray<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -174,6 +177,7 @@ mod tests {
             some_futile_info: None,
             flattened_range: Range { start: 42, end: 64 },
             field_with_specific_rust_name: "renamed field".to_string(),
+            pancake_data: Some(vec![1, 2, 3]),
         }
     });
 
@@ -198,6 +202,7 @@ mod tests {
             some_futile_info: None,
             flattened_range: Range { start: 42, end: 64 },
             field_with_specific_rust_name: "renamed field".to_string(),
+            pancake_data: None,
         }
     });
 }

--- a/ffi-convert/Cargo.toml
+++ b/ffi-convert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi-convert"
-version = "0.6.0-pre"
+version = "0.5.0-pre"
 authors = ["Sonos"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/ffi-convert/Cargo.toml
+++ b/ffi-convert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi-convert"
-version = "0.5.0-pre"
+version = "0.6.0-pre"
 authors = ["Sonos"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/ffi-convert/src/conversions.rs
+++ b/ffi-convert/src/conversions.rs
@@ -295,6 +295,7 @@ impl RawBorrow<libc::c_char> for std::ffi::CStr {
 }
 
 impl_c_drop_for!(usize);
+impl_c_drop_for!(i8);
 impl_c_drop_for!(u8);
 impl_c_drop_for!(i16);
 impl_c_drop_for!(u16);
@@ -308,6 +309,8 @@ impl_c_drop_for!(bool);
 impl_c_drop_for!(std::ffi::CString);
 
 impl_c_repr_of_for!(usize);
+impl_c_repr_of_for!(i8);
+impl_c_repr_of_for!(u8);
 impl_c_repr_of_for!(i16);
 impl_c_repr_of_for!(u16);
 impl_c_repr_of_for!(i32);
@@ -320,12 +323,6 @@ impl_c_repr_of_for!(bool);
 
 impl_c_repr_of_for!(usize, i32);
 
-impl CReprOf<bool> for u8 {
-    fn c_repr_of(input: bool) -> Result<u8, CReprOfError> {
-        Ok(if input { 1 } else { 0 })
-    }
-}
-
 impl CReprOf<String> for std::ffi::CString {
     fn c_repr_of(input: String) -> Result<Self, CReprOfError> {
         Ok(std::ffi::CString::new(input)?)
@@ -333,6 +330,8 @@ impl CReprOf<String> for std::ffi::CString {
 }
 
 impl_as_rust_for!(usize);
+impl_as_rust_for!(i8);
+impl_as_rust_for!(u8);
 impl_as_rust_for!(i16);
 impl_as_rust_for!(u16);
 impl_as_rust_for!(i32);
@@ -344,12 +343,6 @@ impl_as_rust_for!(f64);
 impl_as_rust_for!(bool);
 
 impl_as_rust_for!(i32, usize);
-
-impl AsRust<bool> for u8 {
-    fn as_rust(&self) -> Result<bool, AsRustError> {
-        Ok((*self) != 0)
-    }
-}
 
 impl AsRust<String> for std::ffi::CStr {
     fn as_rust(&self) -> Result<String, AsRustError> {


### PR DESCRIPTION
I believe u8 and i8 were not supported because bool was converted to u8, and that caused conflicts. However in 2018 the C repr of bool was specified to be the same as _Bool in C, therefore we can just have bool convert to bool and then add proper support for u8 and i8.

I also updated the version number since this is a breaking change (you have to change `u8` to `bool` in the `CPizza` structs).

Fixes #38 as far as I can tell.