### PR TITLE
Performance improvement for CArray<_> <-> Vec<_>

### DIFF
--- a/ffi-convert/src/lib.rs
+++ b/ffi-convert/src/lib.rs
@@ -198,8 +198,6 @@
 //!
 //! This conversion trait comes in handy for C-like struct that have fields that points to other structs.
 
-use std::any::TypeId;
-
 pub use ffi_convert_derive::*;
 
 mod conversions;
@@ -207,14 +205,3 @@ mod types;
 
 pub use conversions::*;
 pub use types::*;
-
-fn is_primitive(id: TypeId) -> bool {
-    id == TypeId::of::<u8>()
-        || id == TypeId::of::<i8>()
-        || id == TypeId::of::<u16>()
-        || id == TypeId::of::<i16>()
-        || id == TypeId::of::<u32>()
-        || id == TypeId::of::<i32>()
-        || id == TypeId::of::<f32>()
-        || id == TypeId::of::<f64>()
-}

--- a/ffi-convert/src/lib.rs
+++ b/ffi-convert/src/lib.rs
@@ -198,6 +198,8 @@
 //!
 //! This conversion trait comes in handy for C-like struct that have fields that points to other structs.
 
+use std::any::TypeId;
+
 pub use ffi_convert_derive::*;
 
 mod conversions;
@@ -205,3 +207,14 @@ mod types;
 
 pub use conversions::*;
 pub use types::*;
+
+fn is_primitive(id: TypeId) -> bool {
+    id == TypeId::of::<u8>()
+        || id == TypeId::of::<i8>()
+        || id == TypeId::of::<u16>()
+        || id == TypeId::of::<i16>()
+        || id == TypeId::of::<u32>()
+        || id == TypeId::of::<i32>()
+        || id == TypeId::of::<f32>()
+        || id == TypeId::of::<f64>()
+}

--- a/ffi-convert/src/types.rs
+++ b/ffi-convert/src/types.rs
@@ -1,11 +1,12 @@
 //! This module contains definitions of utility types that implement the [`CReprOf`], [`AsRust`], and [`CDrop`] traits.
 //!
 
+use std::any::TypeId;
 use std::ffi::{CStr, CString};
 use std::ops::Range;
-use std::ptr::null;
+use std::ptr;
 
-use crate::conversions::*;
+use crate::{conversions::*, is_primitive};
 
 /// A utility type to represent arrays of string
 /// # Example
@@ -114,38 +115,64 @@ pub struct CArray<T> {
     size: usize,
 }
 
-impl<U: AsRust<V>, V> AsRust<Vec<V>> for CArray<U> {
+impl<U: AsRust<V> + 'static, V> AsRust<Vec<V>> for CArray<U> {
     fn as_rust(&self) -> Result<Vec<V>, AsRustError> {
         let mut vec = Vec::with_capacity(self.size);
         if self.size > 0 {
-            let values =
-                unsafe { std::slice::from_raw_parts_mut(self.data_ptr as *mut U, self.size) };
-            for value in values {
-                vec.push(value.as_rust()?);
+            if is_primitive(TypeId::of::<U>()) {
+                unsafe {
+                    ptr::copy(
+                        self.data_ptr as *const V,
+                        vec.as_mut_ptr() as *mut V,
+                        self.size,
+                    )
+                };
+            } else {
+                let values =
+                    unsafe { std::slice::from_raw_parts_mut(self.data_ptr as *mut U, self.size) };
+                for value in values {
+                    vec.push(value.as_rust()?);
+                }
             }
         }
         Ok(vec)
     }
 }
 
-impl<U: CReprOf<V> + CDrop, V> CReprOf<Vec<V>> for CArray<U> {
+impl<U: CReprOf<V> + CDrop, V: 'static> CReprOf<Vec<V>> for CArray<U> {
     fn c_repr_of(input: Vec<V>) -> Result<Self, CReprOfError> {
         let input_size = input.len();
-        Ok(Self {
-            data_ptr: if input_size > 0 {
-                Box::into_raw(
+        let mut output: CArray<U> = CArray {
+            data_ptr: ptr::null(),
+            size: input_size,
+        };
+
+        if input_size > 0 {
+            if is_primitive(TypeId::of::<V>()) {
+                let mut data = Vec::<V>::with_capacity(input_size);
+                unsafe {
+                    data.set_len(input_size);
+                    ptr::copy(
+                        input.as_ptr() as *const U,
+                        data.as_mut_ptr() as *mut U,
+                        input_size,
+                    )
+                };
+                output.data_ptr = Box::into_raw(data.into_boxed_slice()) as *const U;
+            } else {
+                output.data_ptr = Box::into_raw(
                     input
                         .into_iter()
                         .map(U::c_repr_of)
                         .collect::<Result<Vec<_>, CReprOfError>>()
                         .expect("Could not convert to C representation")
                         .into_boxed_slice(),
-                ) as *const U
-            } else {
-                null() as *const U
-            },
-            size: input_size,
-        })
+                ) as *const U;
+            }
+        } else {
+            output.data_ptr = ptr::null() as *const U;
+        }
+        Ok(output)
     }
 }
 


### PR DESCRIPTION
Add specific cases for AsRust and CReprOf when the source/target is a Vec/CArray: when it is a primitive, a ptr::copy(...) is used instead of pushing, the result is a great performance improvement for Vec of primitive values.

On my machine, passing from a CArray<c_uchar> of 2MB to a Vec<u8> took 4ms.
With this improvement, it take less than 70us.

