### PR TITLE
Make `CArray` fields public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Make `CArray` fields public
 
 ### Fixed
 

--- a/ffi-convert/src/types.rs
+++ b/ffi-convert/src/types.rs
@@ -114,8 +114,10 @@ impl Drop for CStringArray {
 #[repr(C)]
 #[derive(Debug)]
 pub struct CArray<T> {
-    data_ptr: *const T,
-    size: usize,
+    /// Pointer to the first element of the array
+    pub data_ptr: *const T,
+    /// Number of elements in the array
+    pub size: usize,
 }
 
 impl<U: AsRust<V> + 'static, V> AsRust<Vec<V>> for CArray<U> {


### PR DESCRIPTION
Expose `CArray` fields so that anyone can create one.

Example usage:

```
#[repr(C)]
pub struct CMyStruct {
    pub my_array: *const MyType,
    pub my_array_size: libc::size_t
}

impl AsRust<MyStruct> for CMyStruct {
    fn as_rust(&self) -> Result<MyStruct, AsRustError> {
        Ok(MyStruct {
                array: CArray {
                     data_ptr: self.my_array,
                     size: self.my_array_size
                }.as_rust()?
        })
    }
}

```
