### PR TITLE
Enum support and ASAN/MSAN C roundtrip tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,3 +21,9 @@ jobs:
       run: cargo fmt -- --check
     - name: Clippy
       run: cargo clippy -- -D clippy::all
+    - name: Install nightly toolchain
+      run: rustup toolchain install nightly --component rust-src
+    - name: Run tests under MSan
+      run: cargo +nightly test -Zbuild-std --target=x86_64-unknown-linux-gnu --features msan --verbose
+      env:
+        RUSTFLAGS: -Zsanitizer=memory

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Install nightly toolchain
       run: rustup toolchain install nightly --component rust-src
     - name: Run tests under MSan
-      run: cargo +nightly test -Zbuild-std --target=x86_64-unknown-linux-gnu --features msan --verbose
+      run: cargo +nightly test --lib --tests -Zbuild-std --target=x86_64-unknown-linux-gnu --features msan --verbose
       env:
         RUSTFLAGS: -Zsanitizer=memory

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,10 @@ jobs:
       run: cargo clippy -- -D clippy::all
     - name: Install nightly toolchain
       run: rustup toolchain install nightly --component rust-src
+    - name: Run tests under ASan
+      run: cargo +nightly test --lib --tests -Zbuild-std --target=x86_64-unknown-linux-gnu --features asan --verbose
+      env:
+        RUSTFLAGS: -Zsanitizer=address
     - name: Run tests under MSan
       run: cargo +nightly test --lib --tests -Zbuild-std --target=x86_64-unknown-linux-gnu --features msan --verbose
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - unit enum support
+- added C roundtrips tests with address sanitizer and memeory sanitizer
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - unit enum support
-- added C roundtrips tests with address sanitizer and memeory sanitizer
+- added C roundtrips tests with address sanitizer and memory sanitizer
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- unit enum support
 
 ### Changed
 

--- a/ffi-convert-derive/src/asrust.rs
+++ b/ffi-convert-derive/src/asrust.rs
@@ -3,14 +3,18 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse::{Parse, ParseBuffer};
 
-use crate::utils::{parse_enum_variants, parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath};
+use crate::utils::{
+    parse_enum_variants, parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath,
+};
 
 pub fn impl_asrust_macro(input: &syn::DeriveInput) -> TokenStream {
     let name = &input.ident;
     let target_type = parse_target_type(&input.attrs);
 
     match &input.data {
-        syn::Data::Struct(data_struct) => impl_asrust_struct(name, &target_type, data_struct, input),
+        syn::Data::Struct(data_struct) => {
+            impl_asrust_struct(name, &target_type, data_struct, input)
+        }
         syn::Data::Enum(data_enum) => impl_asrust_enum(name, &target_type, data_enum),
         _ => panic!("AsRust can only be derived for structs and unit enums"),
     }
@@ -125,9 +129,9 @@ fn impl_asrust_enum(
 ) -> TokenStream {
     let variants = parse_enum_variants(data);
 
-    let match_arms = variants.iter().map(|variant| {
-        quote!(#enum_name::#variant => Ok(#target_type::#variant))
-    });
+    let match_arms = variants
+        .iter()
+        .map(|variant| quote!(#enum_name::#variant => Ok(#target_type::#variant)));
 
     quote!(
         impl AsRust<#target_type> for #enum_name {

--- a/ffi-convert-derive/src/asrust.rs
+++ b/ffi-convert-derive/src/asrust.rs
@@ -3,13 +3,26 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse::{Parse, ParseBuffer};
 
-use crate::utils::{parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath};
+use crate::utils::{parse_enum_variants, parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath};
 
 pub fn impl_asrust_macro(input: &syn::DeriveInput) -> TokenStream {
-    let struct_name = &input.ident;
+    let name = &input.ident;
     let target_type = parse_target_type(&input.attrs);
 
-    let fields = parse_struct_fields(&input.data)
+    match &input.data {
+        syn::Data::Struct(data_struct) => impl_asrust_struct(name, &target_type, data_struct, input),
+        syn::Data::Enum(data_enum) => impl_asrust_enum(name, &target_type, data_enum),
+        _ => panic!("AsRust can only be derived for structs and unit enums"),
+    }
+}
+
+fn impl_asrust_struct(
+    struct_name: &syn::Ident,
+    target_type: &syn::Path,
+    data: &syn::DataStruct,
+    input: &syn::DeriveInput,
+) -> TokenStream {
+    let fields = parse_struct_fields(data)
         .iter()
         .filter_map(|field| {
             let Field {
@@ -99,6 +112,29 @@ pub fn impl_asrust_macro(input: &syn::DeriveInput) -> TokenStream {
                     #(#fields, )*
                     #(#extra_fields, )*
                 })
+            }
+        }
+    )
+    .into()
+}
+
+fn impl_asrust_enum(
+    enum_name: &syn::Ident,
+    target_type: &syn::Path,
+    data: &syn::DataEnum,
+) -> TokenStream {
+    let variants = parse_enum_variants(data);
+
+    let match_arms = variants.iter().map(|variant| {
+        quote!(#enum_name::#variant => Ok(#target_type::#variant))
+    });
+
+    quote!(
+        impl AsRust<#target_type> for #enum_name {
+            fn as_rust(&self) -> Result<#target_type, ffi_convert::AsRustError> {
+                match self {
+                    #(#match_arms,)*
+                }
             }
         }
     )

--- a/ffi-convert-derive/src/cdrop.rs
+++ b/ffi-convert-derive/src/cdrop.rs
@@ -3,10 +3,22 @@ use proc_macro::TokenStream;
 use quote::quote;
 
 pub fn impl_cdrop_macro(input: &syn::DeriveInput) -> TokenStream {
-    let struct_name = &input.ident;
+    let name = &input.ident;
     let disable_drop_impl = parse_no_drop_impl_flag(&input.attrs);
 
-    let fields = parse_struct_fields(&input.data);
+    match &input.data {
+        syn::Data::Struct(data_struct) => impl_cdrop_struct(name, disable_drop_impl, data_struct),
+        syn::Data::Enum(_) => impl_cdrop_enum(name, disable_drop_impl),
+        _ => panic!("CDrop can only be derived for structs and unit enums"),
+    }
+}
+
+fn impl_cdrop_struct(
+    struct_name: &syn::Ident,
+    disable_drop_impl: bool,
+    data: &syn::DataStruct,
+) -> TokenStream {
+    let fields = parse_struct_fields(data);
 
     let do_drop_fields = fields
         .iter()
@@ -49,34 +61,52 @@ pub fn impl_cdrop_macro(input: &syn::DeriveInput) -> TokenStream {
         .collect::<Vec<_>>();
 
     let c_drop_impl = quote!(
-        impl CDrop for # struct_name {
+        impl CDrop for #struct_name {
             fn do_drop(&mut self) -> Result<(), ffi_convert::CDropError> {
                 use ffi_convert::RawPointerConverter;
-                # ( #do_drop_fields; )*
+                #(#do_drop_fields;)*
                 Ok(())
             }
         }
     );
 
     let drop_impl = quote!(
-        impl Drop for # struct_name {
+        impl Drop for #struct_name {
             fn drop(&mut self) {
                 let _ = self.do_drop();
             }
         }
     );
 
-    {
-        if disable_drop_impl {
-            quote! {
-                # c_drop_impl
-            }
-        } else {
-            quote! {
-                # c_drop_impl
-                # drop_impl
+    if disable_drop_impl {
+        quote!(#c_drop_impl)
+    } else {
+        quote!(#c_drop_impl #drop_impl)
+    }
+    .into()
+}
+
+fn impl_cdrop_enum(enum_name: &syn::Ident, disable_drop_impl: bool) -> TokenStream {
+    let c_drop_impl = quote!(
+        impl CDrop for #enum_name {
+            fn do_drop(&mut self) -> Result<(), ffi_convert::CDropError> {
+                Ok(())
             }
         }
+    );
+
+    let drop_impl = quote!(
+        impl Drop for #enum_name {
+            fn drop(&mut self) {
+                let _ = self.do_drop();
+            }
+        }
+    );
+
+    if disable_drop_impl {
+        quote!(#c_drop_impl)
+    } else {
+        quote!(#c_drop_impl #drop_impl)
     }
     .into()
 }

--- a/ffi-convert-derive/src/creprof.rs
+++ b/ffi-convert-derive/src/creprof.rs
@@ -2,13 +2,25 @@ use proc_macro::TokenStream;
 
 use quote::quote;
 
-use crate::utils::{parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath};
+use crate::utils::{parse_enum_variants, parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath};
 
 pub fn impl_creprof_macro(input: &syn::DeriveInput) -> TokenStream {
-    let struct_name = &input.ident;
+    let name = &input.ident;
     let target_type = parse_target_type(&input.attrs);
 
-    let fields = parse_struct_fields(&input.data);
+    match &input.data {
+        syn::Data::Struct(data_struct) => impl_creprof_struct(name, &target_type, data_struct),
+        syn::Data::Enum(data_enum) => impl_creprof_enum(name, &target_type, data_enum),
+        _ => panic!("CReprOf can only be derived for structs and unit enums"),
+    }
+}
+
+fn impl_creprof_struct(
+    struct_name: &syn::Ident,
+    target_type: &syn::Path,
+    data: &syn::DataStruct,
+) -> TokenStream {
+    let fields = parse_struct_fields(data);
     let c_repr_of_fields = fields
         .iter()
         .map(|field| {
@@ -57,15 +69,38 @@ pub fn impl_creprof_macro(input: &syn::DeriveInput) -> TokenStream {
         })
         .collect::<Vec<_>>();
 
-    let c_repr_of_impl = quote!(
-        impl CReprOf<# target_type> for # struct_name {
-            fn c_repr_of(input: # target_type) -> Result<Self, ffi_convert::CReprOfError> {
+    quote!(
+        impl CReprOf<#target_type> for #struct_name {
+            fn c_repr_of(input: #target_type) -> Result<Self, ffi_convert::CReprOfError> {
                 use ffi_convert::RawPointerConverter;
                 Ok(Self {
-                    # ( # c_repr_of_fields, )*
+                    #(#c_repr_of_fields,)*
                 })
             }
         }
-    );
-    c_repr_of_impl.into()
+    )
+    .into()
+}
+
+fn impl_creprof_enum(
+    enum_name: &syn::Ident,
+    target_type: &syn::Path,
+    data: &syn::DataEnum,
+) -> TokenStream {
+    let variants = parse_enum_variants(data);
+
+    let match_arms = variants.iter().map(|variant| {
+        quote!(#target_type::#variant => Ok(#enum_name::#variant))
+    });
+
+    quote!(
+        impl CReprOf<#target_type> for #enum_name {
+            fn c_repr_of(input: #target_type) -> Result<Self, ffi_convert::CReprOfError> {
+                match input {
+                    #(#match_arms,)*
+                }
+            }
+        }
+    )
+    .into()
 }

--- a/ffi-convert-derive/src/creprof.rs
+++ b/ffi-convert-derive/src/creprof.rs
@@ -2,7 +2,9 @@ use proc_macro::TokenStream;
 
 use quote::quote;
 
-use crate::utils::{parse_enum_variants, parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath};
+use crate::utils::{
+    parse_enum_variants, parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath,
+};
 
 pub fn impl_creprof_macro(input: &syn::DeriveInput) -> TokenStream {
     let name = &input.ident;
@@ -89,9 +91,9 @@ fn impl_creprof_enum(
 ) -> TokenStream {
     let variants = parse_enum_variants(data);
 
-    let match_arms = variants.iter().map(|variant| {
-        quote!(#target_type::#variant => Ok(#enum_name::#variant))
-    });
+    let match_arms = variants
+        .iter()
+        .map(|variant| quote!(#target_type::#variant => Ok(#enum_name::#variant)));
 
     quote!(
         impl CReprOf<#target_type> for #enum_name {

--- a/ffi-convert-derive/src/utils.rs
+++ b/ffi-convert-derive/src/utils.rs
@@ -16,10 +16,7 @@ pub fn parse_no_drop_impl_flag(attrs: &[syn::Attribute]) -> bool {
 }
 
 pub fn parse_struct_fields(data: &syn::DataStruct) -> Vec<Field<'_>> {
-    data.fields
-        .iter()
-        .map(parse_field)
-        .collect::<Vec<Field>>()
+    data.fields.iter().map(parse_field).collect::<Vec<Field>>()
 }
 
 pub fn parse_enum_variants(data: &syn::DataEnum) -> Vec<&syn::Ident> {

--- a/ffi-convert-derive/src/utils.rs
+++ b/ffi-convert-derive/src/utils.rs
@@ -15,15 +15,27 @@ pub fn parse_no_drop_impl_flag(attrs: &[syn::Attribute]) -> bool {
     })
 }
 
-pub fn parse_struct_fields(data: &syn::Data) -> Vec<Field> {
-    match &data {
-        syn::Data::Struct(data_struct) => data_struct
-            .fields
-            .iter()
-            .map(parse_field)
-            .collect::<Vec<Field>>(),
-        _ => panic!("CReprOf / AsRust can only be derived for structs"),
-    }
+pub fn parse_struct_fields(data: &syn::DataStruct) -> Vec<Field<'_>> {
+    data.fields
+        .iter()
+        .map(parse_field)
+        .collect::<Vec<Field>>()
+}
+
+pub fn parse_enum_variants(data: &syn::DataEnum) -> Vec<&syn::Ident> {
+    data.variants
+        .iter()
+        .map(|variant| {
+            if !variant.fields.is_empty() {
+                panic!(
+                    "CReprOf, AsRust, and CDrop derive for enums only supports unit variants \
+                     (no fields). Variant `{}` has fields.",
+                    variant.ident
+                );
+            }
+            &variant.ident
+        })
+        .collect()
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -45,7 +57,7 @@ pub struct Field<'a> {
     pub levels_of_indirection: u32,
 }
 
-pub fn parse_field(field: &syn::Field) -> Field {
+pub fn parse_field(field: &syn::Field) -> Field<'_> {
     let name = field.ident.as_ref().expect("Field should have an ident");
 
     let target_name = field

--- a/ffi-convert-tests/Cargo.toml
+++ b/ffi-convert-tests/Cargo.toml
@@ -13,9 +13,9 @@ ffi-convert = { path ="../ffi-convert" }
 libc = "0.2.66"
 
 [features]
+asan = []
 msan = []
 
 [dev-dependencies]
 cbindgen = "0.29"
 cc = "1"
-tempfile = "3"

--- a/ffi-convert-tests/Cargo.toml
+++ b/ffi-convert-tests/Cargo.toml
@@ -12,6 +12,9 @@ anyhow = "1.0.32"
 ffi-convert = { path ="../ffi-convert" }
 libc = "0.2.66"
 
+[features]
+msan = []
+
 [dev-dependencies]
 cbindgen = "0.29"
 cc = "1"

--- a/ffi-convert-tests/Cargo.toml
+++ b/ffi-convert-tests/Cargo.toml
@@ -4,7 +4,15 @@ version = "0.7.0-pre"
 authors = ["Sonos"]
 edition = "2018"
 
+[lib]
+crate-type = ["rlib", "cdylib"]
+
 [dependencies]
 anyhow = "1.0.32"
 ffi-convert = { path ="../ffi-convert" }
 libc = "0.2.66"
+
+[dev-dependencies]
+cbindgen = "0.29"
+cc = "1"
+tempfile = "3"

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -348,6 +348,7 @@ mod tests {
         let cc_output = compiler
             .to_command()
             .arg(manifest_dir.join("test_round_trip.c"))
+            .arg("-fsanitize=address")
             .arg(format!("-L{}", target_dir.display()))
             .arg("-lffi_convert_tests")
             .arg("-o")
@@ -370,6 +371,23 @@ mod tests {
             "C test failed: {}{}",
             String::from_utf8_lossy(&run.stdout),
             String::from_utf8_lossy(&run.stderr)
+        );
+
+        // Run the ASan canary: a deliberate use-after-free that ASan must catch
+        let canary = std::process::Command::new(&test_binary)
+            .arg("--asan-canary")
+            .env("LD_LIBRARY_PATH", &target_dir)
+            .output()
+            .expect("Failed to run ASan canary");
+        assert!(
+            !canary.status.success(),
+            "ASan canary should have crashed but didn't — is ASan working?"
+        );
+        let canary_stderr = String::from_utf8_lossy(&canary.stderr);
+        assert!(
+            canary_stderr.contains("AddressSanitizer"),
+            "ASan canary crashed but not from ASan: {}",
+            canary_stderr
         );
     }
 }

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -154,16 +154,22 @@ pub enum CFlavor {
     Strawberry,
 }
 
+/// # Safety
+///
+/// `input` must be a valid pointer to a `CPancake`.
 #[no_mangle]
-pub extern "C" fn pancake_round_trip(input: *const CPancake) -> *const CPancake {
+pub unsafe extern "C" fn pancake_round_trip(input: *const CPancake) -> *const CPancake {
     let c_pancake = unsafe { &*input };
     let rust_pancake: Pancake = c_pancake.as_rust().expect("Failed to convert to Rust");
     let c_pancake_roundtrip = CPancake::c_repr_of(rust_pancake).expect("Failed to convert to C");
     Box::into_raw(Box::new(c_pancake_roundtrip))
 }
 
+/// # Safety
+///
+/// `pancake` must be a pointer returned by `pancake_round_trip`. It must not be used after this call.
 #[no_mangle]
-pub extern "C" fn pancake_free(pancake: *const CPancake) {
+pub unsafe extern "C" fn pancake_free(pancake: *const CPancake) {
     unsafe { drop(Box::from_raw(pancake as *mut CPancake)) }
 }
 

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -315,11 +315,7 @@ mod tests {
 
         // Compile the C test
         let mut build = cc::Build::new();
-        build
-            .include(work_dir)
-            .opt_level(0)
-            .target(host)
-            .host(host);
+        build.include(work_dir).opt_level(0).target(host).host(host);
         if let Some(cc) = compiler_override {
             build.compiler(cc);
         }
@@ -421,9 +417,15 @@ mod tests {
             .env("CARGO_TARGET_DIR", work_dir);
 
         let lib_dir = if let Some(san) = sanitizer {
-            cmd.args(["+nightly", "build", "-p", "ffi-convert-tests", "-Zbuild-std"])
-                .arg(format!("--target={host}"))
-                .env("RUSTFLAGS", format!("-Zsanitizer={san}"));
+            cmd.args([
+                "+nightly",
+                "build",
+                "-p",
+                "ffi-convert-tests",
+                "-Zbuild-std",
+            ])
+            .arg(format!("--target={host}"))
+            .env("RUSTFLAGS", format!("-Zsanitizer={san}"));
             work_dir.join(&host).join("debug")
         } else {
             cmd.args(["build", "-p", "ffi-convert-tests"]);
@@ -459,7 +461,14 @@ mod tests {
         let (lib_dir, host) = build_cdylib(&work_dir, Some("address"));
 
         let test_binary = work_dir.join("test_round_trip");
-        compile_c_test(&work_dir, &lib_dir, &host, Some("-fsanitize=address"), None, &test_binary);
+        compile_c_test(
+            &work_dir,
+            &lib_dir,
+            &host,
+            Some("-fsanitize=address"),
+            None,
+            &test_binary,
+        );
         run_c_test(&test_binary, &lib_dir);
         run_sanitizer_canary(&test_binary, &lib_dir, "--asan-canary", "ASAN_OPTIONS");
     }
@@ -473,7 +482,14 @@ mod tests {
 
         let test_binary = work_dir.join("test_round_trip_msan");
         // MSan requires clang — gcc doesn't support it
-        compile_c_test(&work_dir, &lib_dir, &host, Some("-fsanitize=memory"), Some("clang"), &test_binary);
+        compile_c_test(
+            &work_dir,
+            &lib_dir,
+            &host,
+            Some("-fsanitize=memory"),
+            Some("clang"),
+            &test_binary,
+        );
         run_c_test(&test_binary, &lib_dir);
         run_sanitizer_canary(&test_binary, &lib_dir, "--msan-canary", "MSAN_OPTIONS");
     }

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -425,9 +425,19 @@ mod tests {
         generate_c_header(tmp_dir.path());
 
         let test_binary = tmp_dir.path().join("test_round_trip");
-        compile_c_test(tmp_dir.path(), &target_dir, "-fsanitize=address", &test_binary);
+        compile_c_test(
+            tmp_dir.path(),
+            &target_dir,
+            "-fsanitize=address",
+            &test_binary,
+        );
         run_c_test(&test_binary, &target_dir);
-        run_sanitizer_canary(&test_binary, &target_dir, "--asan-canary", "AddressSanitizer");
+        run_sanitizer_canary(
+            &test_binary,
+            &target_dir,
+            "--asan-canary",
+            "AddressSanitizer",
+        );
     }
 
     #[test]

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -430,7 +430,7 @@ mod tests {
             work_dir.join(&host).join("debug")
         } else {
             // Clear RUSTFLAGS to avoid inheriting sanitizer flags from the
-            // parent process 
+            // parent process
             cmd.args(["build", "-p", "ffi-convert-tests"])
                 .env("RUSTFLAGS", "");
             work_dir.join("debug")

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -49,6 +49,7 @@ pub struct Pancake {
     pub flattened_range: Range<i64>,
     pub field_with_specific_rust_name: String,
     pub pancake_data: Option<Vec<u8>>,
+    pub extra_ice_cream_flavor: Flavor,
 }
 
 #[repr(C)]
@@ -81,6 +82,7 @@ pub struct CPancake {
     pub field_with_specific_c_name: *const libc::c_char,
     #[nullable]
     pancake_data: *const CArray<u8>,
+    extra_ice_cream_flavor: CFlavor,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -136,9 +138,33 @@ pub struct CDummy {
     describe: *const libc::c_char,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Flavor {
+    Vanilla,
+    Chocolate,
+    Strawberry,
+}
+
+#[repr(C)]
+#[derive(CReprOf, AsRust, CDrop)]
+#[target_type(Flavor)]
+pub enum CFlavor {
+    Vanilla,
+    Chocolate,
+    Strawberry,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    generate_round_trip_rust_c_rust!(round_trip_flavor_vanilla, Flavor, CFlavor, {
+        Flavor::Vanilla
+    });
+
+    generate_round_trip_rust_c_rust!(round_trip_flavor_chocolate, Flavor, CFlavor, {
+        Flavor::Chocolate
+    });
 
     generate_round_trip_rust_c_rust!(round_trip_sauce, Sauce, CSauce, { Sauce { volume: 4.2 } });
 
@@ -197,6 +223,7 @@ mod tests {
             flattened_range: Range { start: 42, end: 64 },
             field_with_specific_rust_name: "renamed field".to_string(),
             pancake_data: Some(vec![1, 2, 3]),
+            extra_ice_cream_flavor: Flavor::Chocolate,
         }
     });
 
@@ -237,6 +264,7 @@ mod tests {
             flattened_range: Range { start: 42, end: 64 },
             field_with_specific_rust_name: "renamed field".to_string(),
             pancake_data: None,
+            extra_ice_cream_flavor: Flavor::Strawberry,
         }
     });
 }

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -352,6 +352,7 @@ mod tests {
         );
     }
 
+    #[cfg(any(feature = "asan", feature = "msan"))]
     const SANITIZER_EXIT_CODE: i32 = 42;
 
     #[cfg(any(feature = "asan", feature = "msan"))]
@@ -428,7 +429,10 @@ mod tests {
             .env("RUSTFLAGS", format!("-Zsanitizer={san}"));
             work_dir.join(&host).join("debug")
         } else {
-            cmd.args(["build", "-p", "ffi-convert-tests"]);
+            // Clear RUSTFLAGS to avoid inheriting sanitizer flags from the
+            // parent process 
+            cmd.args(["build", "-p", "ffi-convert-tests"])
+                .env("RUSTFLAGS", "");
             work_dir.join("debug")
         };
 

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -356,29 +356,34 @@ mod tests {
         );
     }
 
+    const SANITIZER_EXIT_CODE: i32 = 42;
+
     #[cfg(any(feature = "asan", feature = "msan"))]
     fn run_sanitizer_canary(
         binary: &std::path::Path,
         lib_dir: &std::path::Path,
         canary_flag: &str,
-        expected_stderr: &str,
+        sanitizer_options_env: &str,
     ) {
         let canary = std::process::Command::new(binary)
             .arg(canary_flag)
             .env("LD_LIBRARY_PATH", lib_dir)
+            .env(
+                sanitizer_options_env,
+                format!("exitcode={SANITIZER_EXIT_CODE}"),
+            )
             .output()
             .expect("Failed to run sanitizer canary");
-        assert!(
-            !canary.status.success(),
-            "Sanitizer canary ({}) should have crashed but didn't",
-            canary_flag
-        );
-        let stderr = String::from_utf8_lossy(&canary.stderr);
-        assert!(
-            stderr.contains(expected_stderr),
-            "Canary ({}) crashed but not from expected sanitizer: {}",
+        // The canary binary returns 0 if it ran to completion (sanitizer didn't
+        // fire). We expect the sanitizer to kill it with our configured exit code.
+        assert_eq!(
+            canary.status.code(),
+            Some(SANITIZER_EXIT_CODE),
+            "Sanitizer canary ({}) exited with unexpected code (expected {}):\nstdout: {}\nstderr: {}",
             canary_flag,
-            stderr
+            SANITIZER_EXIT_CODE,
+            String::from_utf8_lossy(&canary.stdout),
+            String::from_utf8_lossy(&canary.stderr),
         );
     }
 
@@ -456,7 +461,7 @@ mod tests {
         let test_binary = work_dir.join("test_round_trip");
         compile_c_test(&work_dir, &lib_dir, &host, Some("-fsanitize=address"), None, &test_binary);
         run_c_test(&test_binary, &lib_dir);
-        run_sanitizer_canary(&test_binary, &lib_dir, "--asan-canary", "AddressSanitizer");
+        run_sanitizer_canary(&test_binary, &lib_dir, "--asan-canary", "ASAN_OPTIONS");
     }
 
     #[test]
@@ -470,6 +475,6 @@ mod tests {
         // MSan requires clang — gcc doesn't support it
         compile_c_test(&work_dir, &lib_dir, &host, Some("-fsanitize=memory"), Some("clang"), &test_binary);
         run_c_test(&test_binary, &lib_dir);
-        run_sanitizer_canary(&test_binary, &lib_dir, "--msan-canary", "MemorySanitizer");
+        run_sanitizer_canary(&test_binary, &lib_dir, "--msan-canary", "MSAN_OPTIONS");
     }
 }

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -287,7 +287,118 @@ mod tests {
         }
     });
 
+    /// Helper: detect the host target triple from rustc.
+    fn host_target() -> String {
+        let output = std::process::Command::new("rustc")
+            .arg("-vV")
+            .output()
+            .expect("Failed to run rustc");
+        let info = String::from_utf8_lossy(&output.stdout);
+        info.lines()
+            .find_map(|l| l.strip_prefix("host: "))
+            .expect("Could not determine host target from rustc")
+            .to_string()
+    }
+
+    /// Helper: generate the C header with cbindgen into the given directory.
+    fn generate_c_header(header_dir: &std::path::Path) {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let header_path = header_dir.join("ffi_convert_tests.h");
+        let mut config = cbindgen::Config::default();
+        config.language = cbindgen::Language::C;
+        config.parse = cbindgen::ParseConfig {
+            parse_deps: true,
+            include: Some(vec!["ffi-convert".to_string()]),
+            ..Default::default()
+        };
+        let bindings = cbindgen::Builder::new()
+            .with_crate(manifest_dir)
+            .with_config(config)
+            .generate()
+            .expect("Failed to generate C bindings");
+        bindings.write_to_file(&header_path);
+    }
+
+    /// Helper: set the env vars that the cc crate expects outside of build.rs.
+    fn setup_cc_env(host_target: &str) {
+        std::env::set_var("TARGET", host_target);
+        std::env::set_var("HOST", host_target);
+        std::env::set_var("OPT_LEVEL", "0");
+    }
+
+    /// Helper: compile the C test with the given sanitizer flag and link against the cdylib.
+    fn compile_c_test(
+        header_dir: &std::path::Path,
+        lib_dir: &std::path::Path,
+        sanitizer_flag: &str,
+        output: &std::path::Path,
+    ) {
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let compiler = cc::Build::new()
+            .include(header_dir)
+            .opt_level(0)
+            .get_compiler();
+        let cc_output = compiler
+            .to_command()
+            .arg(manifest_dir.join("test_round_trip.c"))
+            .arg(sanitizer_flag)
+            .arg(format!("-L{}", lib_dir.display()))
+            .arg("-lffi_convert_tests")
+            .arg("-o")
+            .arg(output)
+            .output()
+            .expect("Failed to run C compiler");
+        assert!(
+            cc_output.status.success(),
+            "C compilation failed: {}",
+            String::from_utf8_lossy(&cc_output.stderr)
+        );
+    }
+
+    /// Helper: run the C test binary and assert success.
+    fn run_c_test(binary: &std::path::Path, lib_dir: &std::path::Path) {
+        let run = std::process::Command::new(binary)
+            .env("LD_LIBRARY_PATH", lib_dir)
+            .output()
+            .expect("Failed to run C test");
+        assert!(
+            run.status.success(),
+            "C test failed: {}{}",
+            String::from_utf8_lossy(&run.stdout),
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
+
+    /// Helper: run the C test binary with a canary flag and assert the sanitizer catches it.
+    fn run_sanitizer_canary(
+        binary: &std::path::Path,
+        lib_dir: &std::path::Path,
+        canary_flag: &str,
+        expected_stderr: &str,
+    ) {
+        let canary = std::process::Command::new(binary)
+            .arg(canary_flag)
+            .env("LD_LIBRARY_PATH", lib_dir)
+            .output()
+            .expect("Failed to run sanitizer canary");
+        assert!(
+            !canary.status.success(),
+            "Sanitizer canary ({}) should have crashed but didn't",
+            canary_flag
+        );
+        let stderr = String::from_utf8_lossy(&canary.stderr);
+        assert!(
+            stderr.contains(expected_stderr),
+            "Canary ({}) crashed but not from expected sanitizer: {}",
+            canary_flag,
+            stderr
+        );
+    }
+
     #[test]
+    #[cfg(not(feature = "msan"))]
+    // we force clang via an env var in the test runner process in the msan roundtip test, so let's
+    // disable the default round trip test to avoid weird errors
     fn c_round_trip() {
         let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
         let workspace_dir = manifest_dir.parent().unwrap();
@@ -309,85 +420,55 @@ mod tests {
             String::from_utf8_lossy(&cargo_build.stderr)
         );
 
-        // Generate C header with cbindgen
-        let header_path = tmp_dir.path().join("ffi_convert_tests.h");
-        let mut config = cbindgen::Config::default();
-        config.language = cbindgen::Language::C;
-        config.parse = cbindgen::ParseConfig {
-            parse_deps: true,
-            include: Some(vec!["ffi-convert".to_string()]),
-            ..Default::default()
-        };
-        let bindings = cbindgen::Builder::new()
-            .with_crate(manifest_dir.to_str().unwrap())
-            .with_config(config)
-            .generate()
-            .expect("Failed to generate C bindings");
-        bindings.write_to_file(&header_path);
-
-        // Compile the C test and link against the cdylib.
-        // The cc crate expects cargo build-script env vars, so we provide them.
-        let rustc_output = std::process::Command::new("rustc")
-            .arg("-vV")
-            .output()
-            .expect("Failed to run rustc");
-        let rustc_info = String::from_utf8_lossy(&rustc_output.stdout);
-        let host_target = rustc_info
-            .lines()
-            .find_map(|l| l.strip_prefix("host: "))
-            .expect("Could not determine host target from rustc");
-        std::env::set_var("TARGET", host_target);
-        std::env::set_var("HOST", host_target);
-        std::env::set_var("OPT_LEVEL", "0");
+        let host = host_target();
+        setup_cc_env(&host);
+        generate_c_header(tmp_dir.path());
 
         let test_binary = tmp_dir.path().join("test_round_trip");
-        let compiler = cc::Build::new()
-            .include(tmp_dir.path())
-            .opt_level(0)
-            .get_compiler();
-        let cc_output = compiler
-            .to_command()
-            .arg(manifest_dir.join("test_round_trip.c"))
-            .arg("-fsanitize=address")
-            .arg(format!("-L{}", target_dir.display()))
-            .arg("-lffi_convert_tests")
-            .arg("-o")
-            .arg(&test_binary)
+        compile_c_test(tmp_dir.path(), &target_dir, "-fsanitize=address", &test_binary);
+        run_c_test(&test_binary, &target_dir);
+        run_sanitizer_canary(&test_binary, &target_dir, "--asan-canary", "AddressSanitizer");
+    }
+
+    #[test]
+    #[cfg(feature = "msan")]
+    fn c_round_trip_msan() {
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let workspace_dir = manifest_dir.parent().unwrap();
+        let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+        let host = host_target();
+
+        // Build the cdylib with MSan instrumentation (requires nightly + rust-src)
+        let target_dir = tmp_dir.path().join("target");
+        let cargo_build = std::process::Command::new("cargo")
+            .arg("+nightly")
+            .arg("build")
+            .arg("-p")
+            .arg("ffi-convert-tests")
+            .arg("-Zbuild-std")
+            .arg(format!("--target={}", host))
+            .current_dir(workspace_dir)
+            .env("CARGO_TARGET_DIR", &target_dir)
+            .env("RUSTFLAGS", "-Zsanitizer=memory")
             .output()
-            .expect("Failed to run C compiler");
+            .expect("Failed to run cargo build with MSan");
         assert!(
-            cc_output.status.success(),
-            "C compilation failed: {}",
-            String::from_utf8_lossy(&cc_output.stderr)
+            cargo_build.status.success(),
+            "cargo build with MSan failed: {}",
+            String::from_utf8_lossy(&cargo_build.stderr)
         );
 
-        // Run the C test
-        let run = std::process::Command::new(&test_binary)
-            .env("LD_LIBRARY_PATH", &target_dir)
-            .output()
-            .expect("Failed to run C test");
-        assert!(
-            run.status.success(),
-            "C test failed: {}{}",
-            String::from_utf8_lossy(&run.stdout),
-            String::from_utf8_lossy(&run.stderr)
-        );
+        let lib_dir = target_dir.join(&host).join("debug");
 
-        // Run the ASan canary: a deliberate use-after-free that ASan must catch
-        let canary = std::process::Command::new(&test_binary)
-            .arg("--asan-canary")
-            .env("LD_LIBRARY_PATH", &target_dir)
-            .output()
-            .expect("Failed to run ASan canary");
-        assert!(
-            !canary.status.success(),
-            "ASan canary should have crashed but didn't — is ASan working?"
-        );
-        let canary_stderr = String::from_utf8_lossy(&canary.stderr);
-        assert!(
-            canary_stderr.contains("AddressSanitizer"),
-            "ASan canary crashed but not from ASan: {}",
-            canary_stderr
-        );
+        // MSan requires clang — gcc doesn't support it
+        setup_cc_env(&host);
+        std::env::set_var("CC", "clang");
+        generate_c_header(tmp_dir.path());
+
+        let test_binary = tmp_dir.path().join("test_round_trip_msan");
+        compile_c_test(tmp_dir.path(), &lib_dir, "-fsanitize=memory", &test_binary);
+        run_c_test(&test_binary, &lib_dir);
+        run_sanitizer_canary(&test_binary, &lib_dir, "--msan-canary", "MemorySanitizer");
     }
 }

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -154,6 +154,19 @@ pub enum CFlavor {
     Strawberry,
 }
 
+#[no_mangle]
+pub extern "C" fn pancake_round_trip(input: *const CPancake) -> *const CPancake {
+    let c_pancake = unsafe { &*input };
+    let rust_pancake: Pancake = c_pancake.as_rust().expect("Failed to convert to Rust");
+    let c_pancake_roundtrip = CPancake::c_repr_of(rust_pancake).expect("Failed to convert to C");
+    Box::into_raw(Box::new(c_pancake_roundtrip))
+}
+
+#[no_mangle]
+pub extern "C" fn pancake_free(pancake: *const CPancake) {
+    unsafe { drop(Box::from_raw(pancake as *mut CPancake)) }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -267,4 +280,90 @@ mod tests {
             extra_ice_cream_flavor: Flavor::Strawberry,
         }
     });
+
+    #[test]
+    fn c_round_trip() {
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let workspace_dir = manifest_dir.parent().unwrap();
+        let target_dir = workspace_dir.join("target").join("debug");
+        let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+        // Are we calling cargo from inside the test binary to make sure the cdylib is built ?
+        // yes, watch me.
+        let cargo_build = std::process::Command::new("cargo")
+            .arg("build")
+            .arg("-p")
+            .arg("ffi-convert-tests")
+            .current_dir(workspace_dir)
+            .output()
+            .expect("Failed to run cargo build");
+        assert!(
+            cargo_build.status.success(),
+            "cargo build failed: {}",
+            String::from_utf8_lossy(&cargo_build.stderr)
+        );
+
+        // Generate C header with cbindgen
+        let header_path = tmp_dir.path().join("ffi_convert_tests.h");
+        let mut config = cbindgen::Config::default();
+        config.language = cbindgen::Language::C;
+        config.parse = cbindgen::ParseConfig {
+            parse_deps: true,
+            include: Some(vec!["ffi-convert".to_string()]),
+            ..Default::default()
+        };
+        let bindings = cbindgen::Builder::new()
+            .with_crate(manifest_dir.to_str().unwrap())
+            .with_config(config)
+            .generate()
+            .expect("Failed to generate C bindings");
+        bindings.write_to_file(&header_path);
+
+        // Compile the C test and link against the cdylib.
+        // The cc crate expects cargo build-script env vars, so we provide them.
+        let rustc_output = std::process::Command::new("rustc")
+            .arg("-vV")
+            .output()
+            .expect("Failed to run rustc");
+        let rustc_info = String::from_utf8_lossy(&rustc_output.stdout);
+        let host_target = rustc_info
+            .lines()
+            .find_map(|l| l.strip_prefix("host: "))
+            .expect("Could not determine host target from rustc");
+        std::env::set_var("TARGET", host_target);
+        std::env::set_var("HOST", host_target);
+        std::env::set_var("OPT_LEVEL", "0");
+
+        let test_binary = tmp_dir.path().join("test_round_trip");
+        let compiler = cc::Build::new()
+            .include(tmp_dir.path())
+            .opt_level(0)
+            .get_compiler();
+        let cc_output = compiler
+            .to_command()
+            .arg(manifest_dir.join("test_round_trip.c"))
+            .arg(format!("-L{}", target_dir.display()))
+            .arg("-lffi_convert_tests")
+            .arg("-o")
+            .arg(&test_binary)
+            .output()
+            .expect("Failed to run C compiler");
+        assert!(
+            cc_output.status.success(),
+            "C compilation failed: {}",
+            String::from_utf8_lossy(&cc_output.stderr)
+        );
+
+        // Run the C test
+        let run = std::process::Command::new(&test_binary)
+            .env("LD_LIBRARY_PATH", &target_dir)
+            .output()
+            .expect("Failed to run C test");
+        assert!(
+            run.status.success(),
+            "C test failed: {}{}",
+            String::from_utf8_lossy(&run.stdout),
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
 }

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -287,23 +287,22 @@ mod tests {
         }
     });
 
-    /// Helper: detect the host target triple from rustc.
-    fn host_target() -> String {
-        let output = std::process::Command::new("rustc")
-            .arg("-vV")
-            .output()
-            .expect("Failed to run rustc");
-        let info = String::from_utf8_lossy(&output.stdout);
-        info.lines()
-            .find_map(|l| l.strip_prefix("host: "))
-            .expect("Could not determine host target from rustc")
-            .to_string()
+    fn setup_cc_env(host_target: &str) {
+        std::env::set_var("TARGET", host_target);
+        std::env::set_var("HOST", host_target);
+        std::env::set_var("OPT_LEVEL", "0");
     }
 
-    /// Helper: generate the C header with cbindgen into the given directory.
-    fn generate_c_header(header_dir: &std::path::Path) {
-        let manifest_dir = env!("CARGO_MANIFEST_DIR");
-        let header_path = header_dir.join("ffi_convert_tests.h");
+    fn compile_c_test(
+        work_dir: &std::path::Path,
+        lib_dir: &std::path::Path,
+        sanitizer_flag: Option<&str>,
+        output: &std::path::Path,
+    ) {
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+
+        // Generate the C header with cbindgen
+        let header_path = work_dir.join("ffi_convert_tests.h");
         let mut config = cbindgen::Config::default();
         config.language = cbindgen::Language::C;
         config.parse = cbindgen::ParseConfig {
@@ -317,31 +316,18 @@ mod tests {
             .generate()
             .expect("Failed to generate C bindings");
         bindings.write_to_file(&header_path);
-    }
 
-    /// Helper: set the env vars that the cc crate expects outside of build.rs.
-    fn setup_cc_env(host_target: &str) {
-        std::env::set_var("TARGET", host_target);
-        std::env::set_var("HOST", host_target);
-        std::env::set_var("OPT_LEVEL", "0");
-    }
-
-    /// Helper: compile the C test with the given sanitizer flag and link against the cdylib.
-    fn compile_c_test(
-        header_dir: &std::path::Path,
-        lib_dir: &std::path::Path,
-        sanitizer_flag: &str,
-        output: &std::path::Path,
-    ) {
-        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        // Compile the C test
         let compiler = cc::Build::new()
-            .include(header_dir)
+            .include(work_dir)
             .opt_level(0)
             .get_compiler();
-        let cc_output = compiler
-            .to_command()
-            .arg(manifest_dir.join("test_round_trip.c"))
-            .arg(sanitizer_flag)
+        let mut cmd = compiler.to_command();
+        cmd.arg(manifest_dir.join("test_round_trip.c"));
+        if let Some(flag) = sanitizer_flag {
+            cmd.arg(flag);
+        }
+        let cc_output = cmd
             .arg(format!("-L{}", lib_dir.display()))
             .arg("-lffi_convert_tests")
             .arg("-o")
@@ -355,7 +341,6 @@ mod tests {
         );
     }
 
-    /// Helper: run the C test binary and assert success.
     fn run_c_test(binary: &std::path::Path, lib_dir: &std::path::Path) {
         let run = std::process::Command::new(binary)
             .env("LD_LIBRARY_PATH", lib_dir)
@@ -369,7 +354,7 @@ mod tests {
         );
     }
 
-    /// Helper: run the C test binary with a canary flag and assert the sanitizer catches it.
+    #[cfg(any(feature = "asan", feature = "msan"))]
     fn run_sanitizer_canary(
         binary: &std::path::Path,
         lib_dir: &std::path::Path,
@@ -395,89 +380,106 @@ mod tests {
         );
     }
 
-    #[test]
-    #[cfg(not(feature = "msan"))]
-    // we force clang via an env var in the test runner process in the msan roundtip test, so let's
-    // disable the default round trip test to avoid weird errors
-    fn c_round_trip() {
+    fn work_dir(name: &str) -> std::path::PathBuf {
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let dir = manifest_dir.parent().unwrap().join("target").join(name);
+        std::fs::create_dir_all(&dir).expect("Failed to create work dir");
+        dir
+    }
+
+    /// Build the cdylib, optionally with a sanitizer (requires nightly + rust-src).
+    /// Cargo artifacts go in `work_dir`. Returns `(lib_dir, host_target)`.
+    fn build_cdylib(
+        work_dir: &std::path::Path,
+        sanitizer: Option<&str>,
+    ) -> (std::path::PathBuf, String) {
         let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
         let workspace_dir = manifest_dir.parent().unwrap();
-        let target_dir = workspace_dir.join("target").join("debug");
-        let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+        let output = std::process::Command::new("rustc")
+            .arg("-vV")
+            .output()
+            .expect("Failed to run rustc");
+        let info = String::from_utf8_lossy(&output.stdout);
+        let host = info
+            .lines()
+            .find_map(|l| l.strip_prefix("host: "))
+            .expect("Could not determine host target from rustc")
+            .to_string();
 
         // Are we calling cargo from inside the test binary to make sure the cdylib is built ?
         // yes, watch me.
-        let cargo_build = std::process::Command::new("cargo")
-            .arg("build")
-            .arg("-p")
-            .arg("ffi-convert-tests")
-            .current_dir(workspace_dir)
-            .output()
-            .expect("Failed to run cargo build");
+        let mut cmd = std::process::Command::new("cargo");
+        cmd.current_dir(workspace_dir)
+            .env("CARGO_TARGET_DIR", work_dir);
+
+        let lib_dir = if let Some(san) = sanitizer {
+            cmd.args(["+nightly", "build", "-p", "ffi-convert-tests", "-Zbuild-std"])
+                .arg(format!("--target={host}"))
+                .env("RUSTFLAGS", format!("-Zsanitizer={san}"));
+            work_dir.join(&host).join("debug")
+        } else {
+            cmd.args(["build", "-p", "ffi-convert-tests"]);
+            work_dir.join("debug")
+        };
+
+        let output = cmd.output().expect("Failed to run cargo build");
         assert!(
-            cargo_build.status.success(),
+            output.status.success(),
             "cargo build failed: {}",
-            String::from_utf8_lossy(&cargo_build.stderr)
+            String::from_utf8_lossy(&output.stderr)
         );
 
-        let host = host_target();
+        (lib_dir, host)
+    }
+
+    #[test]
+    #[cfg(not(any(feature = "asan", feature = "msan")))]
+    /// Plain C round-trip test without sanitizers (works on stable).
+    /// Disabled when the `asan` or `msan` features are enabled because those
+    /// tests set process-wide env vars (e.g. CC=clang) that would interfere.
+    fn c_round_trip() {
+        // These tests compile and run a native C binary, skip in cross-compilation contexts.
+        if std::env::var("TARGET").is_ok_and(|t| t != std::env::var("HOST").unwrap_or_default()) {
+            eprintln!("Skipping c_round_trip: cross-compilation detected");
+            return;
+        }
+
+        let work_dir = work_dir("c-test");
+        let (lib_dir, host) = build_cdylib(&work_dir, None);
         setup_cc_env(&host);
-        generate_c_header(tmp_dir.path());
 
-        let test_binary = tmp_dir.path().join("test_round_trip");
-        compile_c_test(
-            tmp_dir.path(),
-            &target_dir,
-            "-fsanitize=address",
-            &test_binary,
-        );
-        run_c_test(&test_binary, &target_dir);
-        run_sanitizer_canary(
-            &test_binary,
-            &target_dir,
-            "--asan-canary",
-            "AddressSanitizer",
-        );
+        let test_binary = work_dir.join("test_round_trip");
+        compile_c_test(&work_dir, &lib_dir, None, &test_binary);
+        run_c_test(&test_binary, &lib_dir);
+    }
+
+    #[test]
+    #[cfg(feature = "asan")]
+    /// C round-trip test with AddressSanitizer on both Rust and C (requires nightly + rust-src).
+    fn c_round_trip_asan() {
+        let work_dir = work_dir("c-test-asan");
+        let (lib_dir, host) = build_cdylib(&work_dir, Some("address"));
+        setup_cc_env(&host);
+
+        let test_binary = work_dir.join("test_round_trip");
+        compile_c_test(&work_dir, &lib_dir, Some("-fsanitize=address"), &test_binary);
+        run_c_test(&test_binary, &lib_dir);
+        run_sanitizer_canary(&test_binary, &lib_dir, "--asan-canary", "AddressSanitizer");
     }
 
     #[test]
     #[cfg(feature = "msan")]
+    /// C round-trip test with MemorySanitizer on both Rust and C (requires nightly + rust-src).
     fn c_round_trip_msan() {
-        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-        let workspace_dir = manifest_dir.parent().unwrap();
-        let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
-
-        let host = host_target();
-
-        // Build the cdylib with MSan instrumentation (requires nightly + rust-src)
-        let target_dir = tmp_dir.path().join("target");
-        let cargo_build = std::process::Command::new("cargo")
-            .arg("+nightly")
-            .arg("build")
-            .arg("-p")
-            .arg("ffi-convert-tests")
-            .arg("-Zbuild-std")
-            .arg(format!("--target={}", host))
-            .current_dir(workspace_dir)
-            .env("CARGO_TARGET_DIR", &target_dir)
-            .env("RUSTFLAGS", "-Zsanitizer=memory")
-            .output()
-            .expect("Failed to run cargo build with MSan");
-        assert!(
-            cargo_build.status.success(),
-            "cargo build with MSan failed: {}",
-            String::from_utf8_lossy(&cargo_build.stderr)
-        );
-
-        let lib_dir = target_dir.join(&host).join("debug");
-
+        let work_dir = work_dir("c-test-msan");
+        let (lib_dir, host) = build_cdylib(&work_dir, Some("memory"));
         // MSan requires clang — gcc doesn't support it
         setup_cc_env(&host);
         std::env::set_var("CC", "clang");
-        generate_c_header(tmp_dir.path());
 
-        let test_binary = tmp_dir.path().join("test_round_trip_msan");
-        compile_c_test(tmp_dir.path(), &lib_dir, "-fsanitize=memory", &test_binary);
+        let test_binary = work_dir.join("test_round_trip_msan");
+        compile_c_test(&work_dir, &lib_dir, Some("-fsanitize=memory"), &test_binary);
         run_c_test(&test_binary, &lib_dir);
         run_sanitizer_canary(&test_binary, &lib_dir, "--msan-canary", "MemorySanitizer");
     }

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -287,16 +287,12 @@ mod tests {
         }
     });
 
-    fn setup_cc_env(host_target: &str) {
-        std::env::set_var("TARGET", host_target);
-        std::env::set_var("HOST", host_target);
-        std::env::set_var("OPT_LEVEL", "0");
-    }
-
     fn compile_c_test(
         work_dir: &std::path::Path,
         lib_dir: &std::path::Path,
+        host: &str,
         sanitizer_flag: Option<&str>,
+        compiler_override: Option<&str>,
         output: &std::path::Path,
     ) {
         let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -318,10 +314,16 @@ mod tests {
         bindings.write_to_file(&header_path);
 
         // Compile the C test
-        let compiler = cc::Build::new()
+        let mut build = cc::Build::new();
+        build
             .include(work_dir)
             .opt_level(0)
-            .get_compiler();
+            .target(host)
+            .host(host);
+        if let Some(cc) = compiler_override {
+            build.compiler(cc);
+        }
+        let compiler = build.get_compiler();
         let mut cmd = compiler.to_command();
         cmd.arg(manifest_dir.join("test_round_trip.c"));
         if let Some(flag) = sanitizer_flag {
@@ -434,23 +436,13 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(feature = "asan", feature = "msan")))]
     /// Plain C round-trip test without sanitizers (works on stable).
-    /// Disabled when the `asan` or `msan` features are enabled because those
-    /// tests set process-wide env vars (e.g. CC=clang) that would interfere.
     fn c_round_trip() {
-        // These tests compile and run a native C binary, skip in cross-compilation contexts.
-        if std::env::var("TARGET").is_ok_and(|t| t != std::env::var("HOST").unwrap_or_default()) {
-            eprintln!("Skipping c_round_trip: cross-compilation detected");
-            return;
-        }
-
         let work_dir = work_dir("c-test");
         let (lib_dir, host) = build_cdylib(&work_dir, None);
-        setup_cc_env(&host);
 
         let test_binary = work_dir.join("test_round_trip");
-        compile_c_test(&work_dir, &lib_dir, None, &test_binary);
+        compile_c_test(&work_dir, &lib_dir, &host, None, None, &test_binary);
         run_c_test(&test_binary, &lib_dir);
     }
 
@@ -460,10 +452,9 @@ mod tests {
     fn c_round_trip_asan() {
         let work_dir = work_dir("c-test-asan");
         let (lib_dir, host) = build_cdylib(&work_dir, Some("address"));
-        setup_cc_env(&host);
 
         let test_binary = work_dir.join("test_round_trip");
-        compile_c_test(&work_dir, &lib_dir, Some("-fsanitize=address"), &test_binary);
+        compile_c_test(&work_dir, &lib_dir, &host, Some("-fsanitize=address"), None, &test_binary);
         run_c_test(&test_binary, &lib_dir);
         run_sanitizer_canary(&test_binary, &lib_dir, "--asan-canary", "AddressSanitizer");
     }
@@ -474,12 +465,10 @@ mod tests {
     fn c_round_trip_msan() {
         let work_dir = work_dir("c-test-msan");
         let (lib_dir, host) = build_cdylib(&work_dir, Some("memory"));
-        // MSan requires clang — gcc doesn't support it
-        setup_cc_env(&host);
-        std::env::set_var("CC", "clang");
 
         let test_binary = work_dir.join("test_round_trip_msan");
-        compile_c_test(&work_dir, &lib_dir, Some("-fsanitize=memory"), &test_binary);
+        // MSan requires clang — gcc doesn't support it
+        compile_c_test(&work_dir, &lib_dir, &host, Some("-fsanitize=memory"), Some("clang"), &test_binary);
         run_c_test(&test_binary, &lib_dir);
         run_sanitizer_canary(&test_binary, &lib_dir, "--msan-canary", "MemorySanitizer");
     }

--- a/ffi-convert-tests/test_round_trip.c
+++ b/ffi-convert-tests/test_round_trip.c
@@ -1,0 +1,176 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include "ffi_convert_tests.h"
+
+void test_full_pancake(void) {
+    CDummy dummy = {
+        .count = 42,
+        .describe = "hello",
+    };
+
+    CTopping toppings_data[] = {{.amount = 2}, {.amount = 3}};
+    CArray_CTopping toppings = {
+        .data_ptr = toppings_data,
+        .size = 2,
+    };
+
+    CLayer layers_data[] = {
+        {.number = 10, .subtitle = "inner"},
+    };
+    CArray_CLayer layers = {
+        .data_ptr = layers_data,
+        .size = 1,
+    };
+
+    CLayer base_layers[3] = {
+        {.number = 0, .subtitle = "flour"},
+        {.number = 1, .subtitle = "dough"},
+        {.number = 2, .subtitle = "tomato"},
+    };
+
+    CSauce sauce = {.volume = 3.14f};
+    float end = 5.0f;
+
+    CRange_i32 range = {.start = 20, .end = 30};
+
+    uint8_t data[] = {0x01, 0x02, 0x03};
+    CArray_u8 pancake_data = {
+        .data_ptr = data,
+        .size = 3,
+    };
+
+    CPancake pancake = {
+        .name = "Full pancake",
+        .description = "A fully loaded pancake",
+        .start = 1.0f,
+        .end = &end,
+        .float_array = {1.0f, 2.0f, 3.0f, 4.0f},
+        .dummy = dummy,
+        .sauce = &sauce,
+        .toppings = &toppings,
+        .layers = &layers,
+        .base_layers = {base_layers[0], base_layers[1], base_layers[2]},
+        .is_delicious = true,
+        .range = range,
+        .flattened_range_start = 10,
+        .flattened_range_end = 20,
+        .field_with_specific_c_name = "renamed",
+        .pancake_data = &pancake_data,
+        .extra_ice_cream_flavor = Strawberry,
+    };
+
+    const CPancake *result = pancake_round_trip(&pancake);
+    assert(result != NULL);
+
+    assert(strcmp(result->name, "Full pancake") == 0);
+    assert(strcmp(result->description, "A fully loaded pancake") == 0);
+    assert(result->start == 1.0f);
+    assert(result->end != NULL);
+    assert(*result->end == 5.0f);
+    assert(result->float_array[0] == 1.0f);
+    assert(result->float_array[3] == 4.0f);
+    assert(result->dummy.count == 42);
+    assert(strcmp(result->dummy.describe, "hello") == 0);
+    assert(result->sauce != NULL);
+    assert(result->sauce->volume == 3.14f);
+    assert(result->toppings->size == 2);
+    assert(result->toppings->data_ptr[0].amount == 2);
+    assert(result->toppings->data_ptr[1].amount == 3);
+    assert(result->layers != NULL);
+    assert(result->layers->size == 1);
+    assert(result->layers->data_ptr[0].number == 10);
+    assert(strcmp(result->layers->data_ptr[0].subtitle, "inner") == 0);
+    assert(result->base_layers[0].number == 0);
+    assert(strcmp(result->base_layers[1].subtitle, "dough") == 0);
+    assert(result->is_delicious == true);
+    assert(result->range.start == 20);
+    assert(result->range.end == 30);
+    assert(result->flattened_range_start == 10);
+    assert(result->flattened_range_end == 20);
+    assert(strcmp(result->field_with_specific_c_name, "renamed") == 0);
+    assert(result->pancake_data != NULL);
+    assert(result->pancake_data->size == 3);
+    assert(result->pancake_data->data_ptr[0] == 0x01);
+    assert(result->pancake_data->data_ptr[2] == 0x03);
+    assert(result->extra_ice_cream_flavor == Strawberry);
+
+    pancake_free(result);
+    printf("  full pancake: OK\n");
+}
+
+void test_minimal_pancake(void) {
+    CDummy dummy = {
+        .count = 0,
+        .describe = "",
+    };
+
+    CArray_CTopping toppings = {
+        .data_ptr = NULL,
+        .size = 0,
+    };
+
+    CLayer base_layers[3] = {
+        {.number = 0, .subtitle = NULL},
+        {.number = 0, .subtitle = NULL},
+        {.number = 0, .subtitle = NULL},
+    };
+
+    CRange_i32 range = {.start = 0, .end = 0};
+
+    CPancake pancake = {
+        .name = "",
+        .description = NULL,
+        .start = 0.0f,
+        .end = NULL,
+        .float_array = {0.0f, 0.0f, 0.0f, 0.0f},
+        .dummy = dummy,
+        .sauce = NULL,
+        .toppings = &toppings,
+        .layers = NULL,
+        .base_layers = {base_layers[0], base_layers[1], base_layers[2]},
+        .is_delicious = false,
+        .range = range,
+        .flattened_range_start = 0,
+        .flattened_range_end = 0,
+        .field_with_specific_c_name = "",
+        .pancake_data = NULL,
+        .extra_ice_cream_flavor = Vanilla,
+    };
+
+    const CPancake *result = pancake_round_trip(&pancake);
+    assert(result != NULL);
+
+    assert(strcmp(result->name, "") == 0);
+    assert(result->description == NULL);
+    assert(result->start == 0.0f);
+    assert(result->end == NULL);
+    assert(result->float_array[0] == 0.0f);
+    assert(result->dummy.count == 0);
+    assert(strcmp(result->dummy.describe, "") == 0);
+    assert(result->sauce == NULL);
+    assert(result->toppings->size == 0);
+    assert(result->layers == NULL);
+    assert(result->base_layers[0].number == 0);
+    assert(result->base_layers[0].subtitle == NULL);
+    assert(result->is_delicious == false);
+    assert(result->range.start == 0);
+    assert(result->range.end == 0);
+    assert(result->flattened_range_start == 0);
+    assert(result->flattened_range_end == 0);
+    assert(strcmp(result->field_with_specific_c_name, "") == 0);
+    assert(result->pancake_data == NULL);
+    assert(result->extra_ice_cream_flavor == Vanilla);
+
+    pancake_free(result);
+    printf("  minimal pancake: OK\n");
+}
+
+int main(void) {
+    printf("C round-trip tests:\n");
+    test_full_pancake();
+    test_minimal_pancake();
+    printf("All C round-trip tests passed!\n");
+    return 0;
+}

--- a/ffi-convert-tests/test_round_trip.c
+++ b/ffi-convert-tests/test_round_trip.c
@@ -203,11 +203,29 @@ void test_asan_canary(void) {
     printf("  asan canary (use-after-free): name=%s\n", result->name);
 }
 
+void test_msan_canary(void) {
+    /* Deliberately read uninitialized memory to verify MSan is working. */
+    int uninit;
+    /* volatile prevents the compiler from optimizing away the read */
+    if (*(volatile int *)&uninit > 0) {
+        printf("  msan canary: uninit was positive\n");
+    } else {
+        printf("  msan canary: uninit was non-positive\n");
+    }
+}
+
 int main(int argc, char **argv) {
     if (argc > 1 && strcmp(argv[1], "--asan-canary") == 0) {
         printf("Triggering ASan canary (should crash):\n");
         test_asan_canary();
         printf("ERROR: ASan did not catch use-after-free!\n");
+        return 1;
+    }
+
+    if (argc > 1 && strcmp(argv[1], "--msan-canary") == 0) {
+        printf("Triggering MSan canary (should crash):\n");
+        test_msan_canary();
+        printf("ERROR: MSan did not catch uninitialized read!\n");
         return 1;
     }
 

--- a/ffi-convert-tests/test_round_trip.c
+++ b/ffi-convert-tests/test_round_trip.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 
@@ -168,39 +169,15 @@ void test_minimal_pancake(void) {
 }
 
 void test_asan_canary(void) {
-    /* Deliberately trigger a use-after-free to verify ASan is working. */
-    CDummy dummy = {.count = 0, .describe = ""};
-    CArray_CTopping toppings = {.data_ptr = NULL, .size = 0};
-    CLayer base_layers[3] = {
-        {.number = 0, .subtitle = NULL},
-        {.number = 0, .subtitle = NULL},
-        {.number = 0, .subtitle = NULL},
-    };
-    CRange_i32 range = {.start = 0, .end = 0};
-    CPancake pancake = {
-        .name = "canary",
-        .description = NULL,
-        .start = 0.0f,
-        .end = NULL,
-        .float_array = {0},
-        .dummy = dummy,
-        .sauce = NULL,
-        .toppings = &toppings,
-        .layers = NULL,
-        .base_layers = {base_layers[0], base_layers[1], base_layers[2]},
-        .is_delicious = false,
-        .range = range,
-        .flattened_range_start = 0,
-        .flattened_range_end = 0,
-        .field_with_specific_c_name = "",
-        .pancake_data = NULL,
-        .extra_ice_cream_flavor = Vanilla,
-    };
-
-    const CPancake *result = pancake_round_trip(&pancake);
-    pancake_free(result);
-    /* use-after-free: ASan should catch this */
-    printf("  asan canary (use-after-free): name=%s\n", result->name);
+    /* Deliberately trigger a heap-buffer-overflow to verify ASan is working.
+       Reading one byte past a heap allocation is caught by ASan but will
+       silently succeed without it (just reads adjacent heap memory). */
+    char *buf = (char *)malloc(1);
+    buf[0] = 'x';
+    /* volatile prevents the compiler from optimizing away the read */
+    char c = ((volatile char *)buf)[1]; /* one byte out of bounds */
+    printf("  asan canary (heap-buffer-overflow): read 0x%02x\n", (unsigned char)c);
+    free(buf);
 }
 
 void test_msan_canary(void) {
@@ -218,15 +195,17 @@ int main(int argc, char **argv) {
     if (argc > 1 && strcmp(argv[1], "--asan-canary") == 0) {
         printf("Triggering ASan canary (should crash):\n");
         test_asan_canary();
-        printf("ERROR: ASan did not catch use-after-free!\n");
-        return 1;
+        /* If we get here the sanitizer didn't fire. Return success so the
+           test harness can distinguish "sanitizer killed us" (non-zero)
+           from "canary ran to completion" (zero) via the exit code. */
+        return 0;
     }
 
     if (argc > 1 && strcmp(argv[1], "--msan-canary") == 0) {
         printf("Triggering MSan canary (should crash):\n");
         test_msan_canary();
-        printf("ERROR: MSan did not catch uninitialized read!\n");
-        return 1;
+        /* Same as above — return success if the sanitizer didn't fire. */
+        return 0;
     }
 
     printf("C round-trip tests:\n");

--- a/ffi-convert-tests/test_round_trip.c
+++ b/ffi-convert-tests/test_round_trip.c
@@ -167,7 +167,50 @@ void test_minimal_pancake(void) {
     printf("  minimal pancake: OK\n");
 }
 
-int main(void) {
+void test_asan_canary(void) {
+    /* Deliberately trigger a use-after-free to verify ASan is working. */
+    CDummy dummy = {.count = 0, .describe = ""};
+    CArray_CTopping toppings = {.data_ptr = NULL, .size = 0};
+    CLayer base_layers[3] = {
+        {.number = 0, .subtitle = NULL},
+        {.number = 0, .subtitle = NULL},
+        {.number = 0, .subtitle = NULL},
+    };
+    CRange_i32 range = {.start = 0, .end = 0};
+    CPancake pancake = {
+        .name = "canary",
+        .description = NULL,
+        .start = 0.0f,
+        .end = NULL,
+        .float_array = {0},
+        .dummy = dummy,
+        .sauce = NULL,
+        .toppings = &toppings,
+        .layers = NULL,
+        .base_layers = {base_layers[0], base_layers[1], base_layers[2]},
+        .is_delicious = false,
+        .range = range,
+        .flattened_range_start = 0,
+        .flattened_range_end = 0,
+        .field_with_specific_c_name = "",
+        .pancake_data = NULL,
+        .extra_ice_cream_flavor = Vanilla,
+    };
+
+    const CPancake *result = pancake_round_trip(&pancake);
+    pancake_free(result);
+    /* use-after-free: ASan should catch this */
+    printf("  asan canary (use-after-free): name=%s\n", result->name);
+}
+
+int main(int argc, char **argv) {
+    if (argc > 1 && strcmp(argv[1], "--asan-canary") == 0) {
+        printf("Triggering ASan canary (should crash):\n");
+        test_asan_canary();
+        printf("ERROR: ASan did not catch use-after-free!\n");
+        return 1;
+    }
+
     printf("C round-trip tests:\n");
     test_full_pancake();
     test_minimal_pancake();

--- a/ffi-convert/src/types.rs
+++ b/ffi-convert/src/types.rs
@@ -67,7 +67,7 @@ impl CReprOf<Vec<String>> for CStringArray {
 impl CDrop for CStringArray {
     fn do_drop(&mut self) -> Result<(), CDropError> {
         unsafe {
-            let y = Box::from_raw(std::slice::from_raw_parts_mut(
+            let y = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
                 self.data as *mut *mut libc::c_char,
                 self.size,
             ));
@@ -175,7 +175,7 @@ impl<T> CDrop for CArray<T> {
     fn do_drop(&mut self) -> Result<(), CDropError> {
         if !self.data_ptr.is_null() {
             let _ = unsafe {
-                Box::from_raw(std::slice::from_raw_parts_mut(
+                Box::from_raw(std::ptr::slice_from_raw_parts_mut(
                     self.data_ptr as *mut T,
                     self.size,
                 ))


### PR DESCRIPTION
This adds support for unit enums. Fixes #57 

I also expanded the roundtrip test we have; this will now generate a C header and compile C \o/