### PR TITLE
Edition 2024, MSRV 1.88

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,10 @@ jobs:
       run: cargo fmt -- --check
     - name: Clippy
       run: cargo clippy -- -D clippy::all
+    - name: Install 1.88 toolchain (MSRV)
+      run: rustup toolchain install 1.88.0
+    - name: Run tests on MSRV
+      run: cargo test --verbose
     - name: Install nightly toolchain
       run: rustup toolchain install nightly --component rust-src
     - name: Run tests under ASan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- move to edition 2024, MSRV 1.88
 
 ### Fixed
 - memory leak on array convertion error and performance / correctness improvement on array convertion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "ffi-convert",
     "ffi-convert-derive",

--- a/ffi-convert-derive/Cargo.toml
+++ b/ffi-convert-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ffi-convert-derive"
 version = "0.8.0-pre"
 authors = ["Sonos"]
-edition = "2018"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Macros implementations of CReprOf, AsRust, CDrop traits from ffi-convert"
 repository = "https://github.com/sonos/ffi-convert-rs"

--- a/ffi-convert-derive/src/asrust.rs
+++ b/ffi-convert-derive/src/asrust.rs
@@ -32,7 +32,7 @@ fn impl_asrust_struct(
             let Field {
                 name: field_name,
                 target_name: target_field_name,
-                ref field_type,
+                field_type,
                 ..
             } = field;
 

--- a/ffi-convert-derive/src/asrust.rs
+++ b/ffi-convert-derive/src/asrust.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use syn::parse::{Parse, ParseBuffer};
 
 use crate::utils::{
-    parse_enum_variants, parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath,
+    Field, TypeArrayOrTypePath, parse_enum_variants, parse_struct_fields, parse_target_type,
 };
 
 pub fn impl_asrust_macro(input: &syn::DeriveInput) -> TokenStream {

--- a/ffi-convert-derive/src/cdrop.rs
+++ b/ffi-convert-derive/src/cdrop.rs
@@ -25,7 +25,7 @@ fn impl_cdrop_struct(
         .map(|field| {
             let Field {
                 name: field_name,
-                ref field_type,
+                field_type,
                 ..
             } = field;
 

--- a/ffi-convert-derive/src/cdrop.rs
+++ b/ffi-convert-derive/src/cdrop.rs
@@ -1,4 +1,4 @@
-use crate::utils::{parse_no_drop_impl_flag, parse_struct_fields, Field, TypeArrayOrTypePath};
+use crate::utils::{Field, TypeArrayOrTypePath, parse_no_drop_impl_flag, parse_struct_fields};
 use proc_macro::TokenStream;
 use quote::quote;
 

--- a/ffi-convert-derive/src/creprof.rs
+++ b/ffi-convert-derive/src/creprof.rs
@@ -3,7 +3,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 
 use crate::utils::{
-    parse_enum_variants, parse_struct_fields, parse_target_type, Field, TypeArrayOrTypePath,
+    Field, TypeArrayOrTypePath, parse_enum_variants, parse_struct_fields, parse_target_type,
 };
 
 pub fn impl_creprof_macro(input: &syn::DeriveInput) -> TokenStream {

--- a/ffi-convert-derive/src/creprof.rs
+++ b/ffi-convert-derive/src/creprof.rs
@@ -29,7 +29,7 @@ fn impl_creprof_struct(
             let Field {
                 name: field_name,
                 target_name: target_field_name,
-                ref field_type,
+                field_type,
                 ..
             } = field;
 

--- a/ffi-convert-tests/Cargo.toml
+++ b/ffi-convert-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ffi-convert-tests"
 version = "0.8.0-pre"
 authors = ["Sonos"]
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -157,7 +157,7 @@ pub enum CFlavor {
 /// # Safety
 ///
 /// `input` must be a valid pointer to a `CPancake`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn pancake_round_trip(input: *const CPancake) -> *const CPancake {
     let c_pancake = unsafe { &*input };
     let rust_pancake: Pancake = c_pancake.as_rust().expect("Failed to convert to Rust");
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn pancake_round_trip(input: *const CPancake) -> *const CP
 /// # Safety
 ///
 /// `pancake` must be a pointer returned by `pancake_round_trip`. It must not be used after this call.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn pancake_free(pancake: *const CPancake) {
     unsafe { drop(Box::from_raw(pancake as *mut CPancake)) }
 }

--- a/ffi-convert-tests/src/lib.rs
+++ b/ffi-convert-tests/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use ffi_convert::*;
 use std::ops::Range;
 

--- a/ffi-convert/Cargo.toml
+++ b/ffi-convert/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ffi-convert"
 version = "0.8.0-pre"
 authors = ["Sonos"]
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "A collection of utilities to ease conversion between Rust and C-compatible data structures."
 repository = "https://github.com/sonos/ffi-convert-rs"

--- a/ffi-convert/src/conversions.rs
+++ b/ffi-convert/src/conversions.rs
@@ -63,12 +63,12 @@ macro_rules! impl_rawpointerconverter_for {
             unsafe fn from_raw_pointer(
                 input: *const $typ,
             ) -> Result<Self, UnexpectedNullPointerError> {
-                take_back_from_raw_pointer(input)
+                unsafe { take_back_from_raw_pointer(input) }
             }
             unsafe fn from_raw_pointer_mut(
                 input: *mut $typ,
             ) -> Result<Self, UnexpectedNullPointerError> {
-                take_back_from_raw_pointer_mut(input)
+                unsafe { take_back_from_raw_pointer_mut(input) }
             }
         }
     };
@@ -156,14 +156,14 @@ pub trait RawPointerConverter<T>: Sized {
     /// # Safety
     /// This method is unsafe for the same reasons as [`Self::from_raw_pointer`]
     unsafe fn drop_raw_pointer(input: *const T) -> Result<(), UnexpectedNullPointerError> {
-        Self::from_raw_pointer(input).map(|_| ())
+        unsafe { Self::from_raw_pointer(input) }.map(|_| ())
     }
 
     /// Takes back control of a raw pointer created by [`Self::into_raw_pointer_mut`] and drops it.
     /// # Safety
     /// This method is unsafe for the same reasons a [`Self::from_raw_pointer_mut`]
     unsafe fn drop_raw_pointer_mut(input: *mut T) -> Result<(), UnexpectedNullPointerError> {
-        Self::from_raw_pointer_mut(input).map(|_| ())
+        unsafe { Self::from_raw_pointer_mut(input) }.map(|_| ())
     }
 }
 
@@ -181,7 +181,7 @@ pub fn convert_into_raw_pointer_mut<T>(pointee: T) -> *mut T {
 pub unsafe fn take_back_from_raw_pointer<T>(
     input: *const T,
 ) -> Result<T, UnexpectedNullPointerError> {
-    take_back_from_raw_pointer_mut(input as _)
+    unsafe { take_back_from_raw_pointer_mut(input as _) }
 }
 
 #[doc(hidden)]
@@ -191,7 +191,7 @@ pub unsafe fn take_back_from_raw_pointer_mut<T>(
     if input.is_null() {
         Err(UnexpectedNullPointerError)
     } else {
-        Ok(*Box::from_raw(input))
+        Ok(*unsafe { Box::from_raw(input) })
     }
 }
 
@@ -218,7 +218,7 @@ pub trait RawBorrowMut<T> {
 /// Trait that allows obtaining a borrowed reference to a type T from a raw pointer to T
 impl<T> RawBorrow<T> for T {
     unsafe fn raw_borrow<'a>(input: *const T) -> Result<&'a Self, UnexpectedNullPointerError> {
-        input.as_ref().ok_or(UnexpectedNullPointerError)
+        unsafe { input.as_ref() }.ok_or(UnexpectedNullPointerError)
     }
 }
 
@@ -227,7 +227,7 @@ impl<T> RawBorrowMut<T> for T {
     unsafe fn raw_borrow_mut<'a>(
         input: *mut T,
     ) -> Result<&'a mut Self, UnexpectedNullPointerError> {
-        input.as_mut().ok_or(UnexpectedNullPointerError)
+        unsafe { input.as_mut() }.ok_or(UnexpectedNullPointerError)
     }
 }
 
@@ -243,7 +243,7 @@ impl RawPointerConverter<libc::c_void> for std::ffi::CString {
     unsafe fn from_raw_pointer(
         input: *const libc::c_void,
     ) -> Result<Self, UnexpectedNullPointerError> {
-        Self::from_raw_pointer_mut(input as *mut libc::c_void)
+        unsafe { Self::from_raw_pointer_mut(input as *mut libc::c_void) }
     }
 
     unsafe fn from_raw_pointer_mut(
@@ -252,7 +252,7 @@ impl RawPointerConverter<libc::c_void> for std::ffi::CString {
         if input.is_null() {
             Err(UnexpectedNullPointerError)
         } else {
-            Ok(std::ffi::CString::from_raw(input as *mut libc::c_char))
+            Ok(unsafe { std::ffi::CString::from_raw(input as *mut libc::c_char) })
         }
     }
 }
@@ -269,7 +269,7 @@ impl RawPointerConverter<libc::c_char> for std::ffi::CString {
     unsafe fn from_raw_pointer(
         input: *const libc::c_char,
     ) -> Result<Self, UnexpectedNullPointerError> {
-        Self::from_raw_pointer_mut(input as *mut libc::c_char)
+        unsafe { Self::from_raw_pointer_mut(input as *mut libc::c_char) }
     }
 
     unsafe fn from_raw_pointer_mut(
@@ -278,7 +278,7 @@ impl RawPointerConverter<libc::c_char> for std::ffi::CString {
         if input.is_null() {
             Err(UnexpectedNullPointerError)
         } else {
-            Ok(std::ffi::CString::from_raw(input as *mut libc::c_char))
+            Ok(unsafe { std::ffi::CString::from_raw(input as *mut libc::c_char) })
         }
     }
 }
@@ -290,7 +290,7 @@ impl RawBorrow<libc::c_char> for std::ffi::CStr {
         if input.is_null() {
             Err(UnexpectedNullPointerError)
         } else {
-            Ok(Self::from_ptr(input))
+            Ok(unsafe { Self::from_ptr(input) })
         }
     }
 }
@@ -393,7 +393,7 @@ where
         // SAFETY: `array` is certain to be initialized
         let array = unsafe {
             // TODO: array_assume_init: https://github.com/rust-lang/rust/issues/96097
-            (core::ptr::addr_of!(array).cast::<[T; N]>()).read()
+            (&raw const array).cast::<[T; N]>().read()
         };
         Ok(array)
     }
@@ -404,12 +404,8 @@ impl<T: CDrop, const N: usize> CDrop for [T; N] {
         let mut result = Ok(());
 
         for value in self {
-            // TODO: edition 2024 let chains: https://doc.rust-lang.org/edition-guide/rust-2024/let-chains.html
-            if let Err(err) = value.do_drop() {
-                // Assign error only if none is already set, preserving the first error
-                if result.is_ok() {
-                    result = Err(err);
-                }
+            if let Err(err) = value.do_drop() && result.is_ok() {
+                result = Err(err);
             }
         }
 
@@ -445,7 +441,7 @@ impl<U: AsRust<T>, T, const N: usize> AsRust<[T; N]> for [U; N] {
         // SAFETY: `array` is certain to be initialized
         let array = unsafe {
             // TODO: array_assume_init: https://github.com/rust-lang/rust/issues/96097
-            (core::ptr::addr_of!(array).cast::<[T; N]>()).read()
+            (&raw const array).cast::<[T; N]>().read()
         };
         Ok(array)
     }

--- a/ffi-convert/src/conversions.rs
+++ b/ffi-convert/src/conversions.rs
@@ -212,7 +212,7 @@ pub trait RawBorrowMut<T> {
     /// # Safety
     /// As this is using `*mut T:as_ref()` this is unsafe for exactly the same reasons.
     unsafe fn raw_borrow_mut<'a>(input: *mut T)
-        -> Result<&'a mut Self, UnexpectedNullPointerError>;
+    -> Result<&'a mut Self, UnexpectedNullPointerError>;
 }
 
 /// Trait that allows obtaining a borrowed reference to a type T from a raw pointer to T
@@ -404,7 +404,9 @@ impl<T: CDrop, const N: usize> CDrop for [T; N] {
         let mut result = Ok(());
 
         for value in self {
-            if let Err(err) = value.do_drop() && result.is_ok() {
+            if let Err(err) = value.do_drop()
+                && result.is_ok()
+            {
                 result = Err(err);
             }
         }

--- a/ffi-convert/src/types.rs
+++ b/ffi-convert/src/types.rs
@@ -203,13 +203,13 @@ impl<T> RawPointerConverter<CArray<T>> for CArray<T> {
     unsafe fn from_raw_pointer(
         input: *const CArray<T>,
     ) -> Result<Self, UnexpectedNullPointerError> {
-        take_back_from_raw_pointer(input)
+        unsafe { take_back_from_raw_pointer(input) }
     }
 
     unsafe fn from_raw_pointer_mut(
         input: *mut CArray<T>,
     ) -> Result<Self, UnexpectedNullPointerError> {
-        take_back_from_raw_pointer_mut(input)
+        unsafe { take_back_from_raw_pointer_mut(input) }
     }
 }
 


### PR DESCRIPTION
Following #59,  @carlocorradini pointed out that we were still using edition 2018. 

Here is a bump to edition 2024, and actually Rust 1.88 to get `if let` chains !

- use `if let` chains in `CDrop` for arrays
- use `&raw` instead of `core::ptr::addr_of!` (cc @carlocorradini )
- added `unsafe {}` blocks when actually doing unsafe things  inside all `unsafe fn` bodies
- removed `ref` in patterns that already implicitly borrow
- use `#[unsafe(no_mangle)]` instread of `#[no_mangle]`
- added compilation on 1.88 on the ci, lets try to be a bit more explicit from now on on the MSRV