### PR TITLE
better errors spans

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,9 @@ jobs:
     - name: Install 1.88 toolchain (MSRV)
       run: rustup toolchain install 1.88.0
     - name: Run tests on MSRV
-      run: cargo test --verbose
+      run: cargo +1.88 test --verbose
+    - name: Clippy on MSRV
+      run: cargo +1.88 clippy -- -D clippy::all
     - name: Install nightly toolchain
       run: rustup toolchain install nightly --component rust-src
     - name: Run tests under ASan

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Clippy
       run: cargo clippy -- -D clippy::all
     - name: Install 1.88 toolchain (MSRV)
-      run: rustup toolchain install 1.88.0
+      run: rustup toolchain install 1.88 --component clippy
     - name: Run tests on MSRV
       run: cargo +1.88 test --verbose
     - name: Clippy on MSRV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- compilation errors in derived code are now linked to the field that provoked them rather than the whole struct
 
 ### Changed
 - move to edition 2024, MSRV 1.88

--- a/ffi-convert-derive/src/asrust.rs
+++ b/ffi-convert-derive/src/asrust.rs
@@ -54,18 +54,14 @@ fn impl_asrust_struct(
             } else if field.is_pointer {
                 match field_type {
                     TypeArrayOrTypePath::TypeArray(type_array) => {
-                        quote_spanned!(field_span => {
-                        let ref_to_array = unsafe { <#type_array>::raw_borrow(self.#field_name)? };
-                        let converted_array = ref_to_struct.as_rust()?;
-                        converted_array
-                    })
+                        quote_spanned!(field_span =>
+                            unsafe { <#type_array>::raw_borrow(self.#field_name)? }.as_rust()?
+                        )
                     }
                     TypeArrayOrTypePath::TypePath(type_path) => {
-                        quote_spanned!(field_span => {
-                        let ref_to_struct = unsafe { #type_path::raw_borrow(self.#field_name)? };
-                        let converted_struct = ref_to_struct.as_rust()?;
-                        converted_struct
-                    })
+                        quote_spanned!(field_span =>
+                            unsafe { #type_path::raw_borrow(self.#field_name)? }.as_rust()?
+                        )
                     }
                 }
 

--- a/ffi-convert-derive/src/asrust.rs
+++ b/ffi-convert-derive/src/asrust.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 
-use quote::quote;
+use quote::{quote, quote_spanned};
 use syn::parse::{Parse, ParseBuffer};
 
 use crate::utils::{
@@ -35,6 +35,7 @@ fn impl_asrust_struct(
                 field_type,
                 ..
             } = field;
+            let field_span = field_name.span();
 
             if field.levels_of_indirection > 1 && !field.is_nullable {
                 panic!(
@@ -46,21 +47,21 @@ fn impl_asrust_struct(
             }
 
             let mut conversion = if field.is_string {
-                quote!( {
+                quote_spanned!(field_span => {
                     use ffi_convert::RawBorrow;
                     unsafe { std::ffi::CStr::raw_borrow(self.#field_name) }?.as_rust()?
                 })
             } else if field.is_pointer {
                 match field_type {
                     TypeArrayOrTypePath::TypeArray(type_array) => {
-                        quote!( {
+                        quote_spanned!(field_span => {
                         let ref_to_array = unsafe { <#type_array>::raw_borrow(self.#field_name)? };
                         let converted_array = ref_to_struct.as_rust()?;
                         converted_array
                     })
                     }
                     TypeArrayOrTypePath::TypePath(type_path) => {
-                        quote!( {
+                        quote_spanned!(field_span => {
                         let ref_to_struct = unsafe { #type_path::raw_borrow(self.#field_name)? };
                         let converted_struct = ref_to_struct.as_rust()?;
                         converted_struct
@@ -69,11 +70,11 @@ fn impl_asrust_struct(
                 }
 
             } else {
-                quote!(self.#field_name.as_rust()?)
+                quote_spanned!(field_span => self.#field_name.as_rust()?)
             };
 
             conversion = if field.is_nullable {
-                quote!(
+                quote_spanned!(field_span =>
                     #target_field_name: if !self.#field_name.is_null() {
                         Some(#conversion)
                     } else {
@@ -81,7 +82,7 @@ fn impl_asrust_struct(
                     }
                 )
             } else {
-                quote!(
+                quote_spanned!(field_span =>
                     #target_field_name: #conversion
                 )
             };

--- a/ffi-convert-derive/src/asrust.rs
+++ b/ffi-convert-derive/src/asrust.rs
@@ -64,7 +64,6 @@ fn impl_asrust_struct(
                         )
                     }
                 }
-
             } else {
                 quote_spanned!(field_span => self.#field_name.as_rust()?)
             };

--- a/ffi-convert-derive/src/creprof.rs
+++ b/ffi-convert-derive/src/creprof.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 
-use quote::quote;
+use quote::{quote, quote_spanned};
 
 use crate::utils::{
     Field, TypeArrayOrTypePath, parse_enum_variants, parse_struct_fields, parse_target_type,
@@ -24,7 +24,7 @@ fn impl_creprof_struct(
 ) -> TokenStream {
     let fields = parse_struct_fields(data);
     let c_repr_of_fields = fields
-        .iter()
+        .into_iter()
         .map(|field| {
             let Field {
                 name: field_name,
@@ -32,28 +32,29 @@ fn impl_creprof_struct(
                 field_type,
                 ..
             } = field;
+            let field_span = field_name.span();
 
             let mut conversion = if field.is_string {
-                quote!(std::ffi::CString::c_repr_of(field)?)
+                quote_spanned!(field_span => std::ffi::CString::c_repr_of(field)?)
             } else {
                 match field_type {
                     TypeArrayOrTypePath::TypeArray(type_array) => {
-                        quote!(<#type_array>::c_repr_of(field)?)
+                        quote_spanned!(field_span => <#type_array>::c_repr_of(field)?)
                     }
                     TypeArrayOrTypePath::TypePath(type_path) => {
-                        quote!(#type_path::c_repr_of(field)?)
+                        quote_spanned!(field_span => #type_path::c_repr_of(field)?)
                     }
                 }
             };
 
             if field.is_pointer {
                 for _ in 0..field.levels_of_indirection {
-                    conversion = quote!(#conversion.into_raw_pointer())
+                    conversion = quote_spanned!(field_span => #conversion.into_raw_pointer())
                 }
             }
 
             conversion = if field.is_nullable {
-                quote!(
+                quote_spanned!(field_span =>
                     #field_name: if let Some(field) = input.#target_field_name {
                         #conversion
                     } else {
@@ -61,10 +62,10 @@ fn impl_creprof_struct(
                     }
                 )
             } else {
-                quote!(#field_name: { let field = input.#target_field_name ; #conversion })
+                quote_spanned!(field_span => #field_name: { let field = input.#target_field_name ; #conversion })
             };
             if let Some(convert) = &field.c_repr_of_convert {
-                quote!(#field_name: #convert)
+                quote_spanned!(field_span => #field_name: #convert)
             } else {
                 conversion
             }


### PR DESCRIPTION
Attach the code we generate to the actual field we generate it for. Should be bit more helpful than the default that attaches it to the derive span. This is especially usefull for example when you forget `#[nullable]` on a field


#### Before:    
```                                                                                                                                                                                                            
  error[E0308]: mismatched types                                                                                                                                                                                         
    --> src/lib.rs:19:10                                                                                                                                                                                                 
     |                                                                                                                                                                                                                   
  19 | #[derive(CReprOf, AsRust, CDrop)]
     |          ^^^^^^^                                                                                                                                                                                                  
     |          |                                                                                                                                                                                                        
     |          expected `Sauce`, found `Option<Sauce>`                                                                                                                                                                  
     |          arguments to this function are incorrect                                                                                                                                                                 
     ...                                                                                                                                                                                                                 
     = note: this error originates in the derive macro `CReprOf`                                                                                                                                                       
  help: consider using `Option::expect` ...                     
     |                                                                                                                                                                                                                   
  19 | #[derive(CReprOf.expect("REASON"), AsRust, CDrop)]                                                                                                                                                                
     |                 +++++++++++++++++                                                                                                                                                                                 
  ```                                                                                                                                                                                                                       
  #### After:    
```                                                                                                                                                                                                           
  error[E0308]: mismatched types                                                                                                                                                                                         
    --> src/lib.rs:22:9                                                                                                                                                                                                
     |                                                                                                                                                                                                                   
  22 |     pub base: *const CSauce, // missing #[nullable]
     |         ^^^^---------------                                                                                                                                                                                       
     |         |                                                                                                                                                                                                       
     |         expected `Sauce`, found `Option<Sauce>`                                                                                                                                                                   
     |         arguments to this function are incorrect
     ...                                                                                                                                                                                                                 
  help: consider using `Option::expect` ...                                                                                                                                                                            
     |                                     
  22 |     pub base.expect("REASON"): *const CSauce, // missing #[nullable]                                                                                                                                              
     |             +++++++++++++++++                                       
  ```                                              

Well the help part from the compiler is still bogus, but at least it is at the error is at the right place.


Doing this surfaced clippy warnings on 1.88.  I fixed those and added clippy on 1.88 on the CI (and we now actually run the tests on 1.88 as well)